### PR TITLE
feat: add --all flag to app list for catalog discoverability

### DIFF
--- a/cmd/sikifanso/app_cmd.go
+++ b/cmd/sikifanso/app_cmd.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"slices"
 	"sort"
 	"strings"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/urfave/cli/v3"
 	"go.uber.org/zap"
 	"golang.org/x/term"
+	"k8s.io/utils/ptr"
 )
 
 func appCmd() *cli.Command {
@@ -70,8 +70,15 @@ func appAddCmd() *cli.Command {
 
 func appListCmd() *cli.Command {
 	return &cli.Command{
-		Name:   "list",
-		Usage:  "List installed apps",
+		Name:  "list",
+		Usage: "List installed apps (use --all to include full catalog)",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:    "all",
+				Aliases: []string{"a"},
+				Usage:   "Show all catalog entries including disabled",
+			},
+		},
 		Action: withSession(appListAction),
 	}
 }
@@ -206,9 +213,33 @@ type appListItem struct {
 	Version   string `json:"version"`
 	Namespace string `json:"namespace"`
 	Source    string `json:"source"`
+	Enabled   *bool  `json:"enabled,omitempty"`
+}
+
+func buildAppListItems(apps []app.AppInfo, catalogEntries []catalog.Entry, showAll bool) []appListItem {
+	items := make([]appListItem, 0, len(apps)+len(catalogEntries))
+	for _, a := range apps {
+		item := appListItem{Name: a.Name, Chart: a.Chart, Version: a.Version, Namespace: a.Namespace, Source: "custom"}
+		if showAll {
+			item.Enabled = ptr.To(true)
+		}
+		items = append(items, item)
+	}
+	for _, e := range catalogEntries {
+		if showAll || e.Enabled {
+			item := appListItem{Name: e.Name, Chart: e.Chart, Version: e.TargetRevision, Namespace: e.Namespace, Source: "catalog"}
+			if showAll {
+				item.Enabled = ptr.To(e.Enabled)
+			}
+			items = append(items, item)
+		}
+	}
+	return items
 }
 
 func appListAction(_ context.Context, cmd *cli.Command, sess *session.Session) error {
+	showAll := cmd.Bool("all")
+
 	apps, err := app.List(sess.GitOpsPath)
 	if err != nil {
 		return fmt.Errorf("listing apps: %w", err)
@@ -219,38 +250,29 @@ func appListAction(_ context.Context, cmd *cli.Command, sess *session.Session) e
 		return fmt.Errorf("listing catalog: %w", err)
 	}
 
+	items := buildAppListItems(apps, catalogEntries, showAll)
+
 	if cmd.String("output") == outputFormatJSON {
-		items := make([]appListItem, 0, len(apps)+len(catalogEntries))
-		for _, a := range apps {
-			items = append(items, appListItem{Name: a.Name, Chart: a.Chart, Version: a.Version, Namespace: a.Namespace, Source: "custom"})
-		}
-		for _, e := range catalogEntries {
-			if e.Enabled {
-				items = append(items, appListItem{Name: e.Name, Chart: e.Chart, Version: e.TargetRevision, Namespace: e.Namespace, Source: "catalog"})
-			}
-		}
 		outputJSON(cmd, items)
 		return nil
 	}
 
-	hasEnabledCatalog := slices.ContainsFunc(catalogEntries, func(e catalog.Entry) bool {
-		return e.Enabled
-	})
-
-	if len(apps) == 0 && !hasEnabledCatalog {
-		fmt.Fprintln(os.Stderr, "No apps installed — add one with: sikifanso app add")
+	if len(items) == 0 {
+		fmt.Fprintln(os.Stderr, "No apps found — add one with: sikifanso app add")
 		return nil
 	}
 
 	headers := []string{"NAME", "CHART", "VERSION", "NAMESPACE", "SOURCE"}
-	rows := make([][]string, 0, len(apps)+len(catalogEntries))
-	for _, a := range apps {
-		rows = append(rows, []string{a.Name, a.Chart, a.Version, a.Namespace, "custom"})
+	if showAll {
+		headers = append(headers, "ENABLED")
 	}
-	for _, e := range catalogEntries {
-		if e.Enabled {
-			rows = append(rows, []string{e.Name, e.Chart, e.TargetRevision, e.Namespace, "catalog"})
+	rows := make([][]string, 0, len(items))
+	for _, item := range items {
+		row := []string{item.Name, item.Chart, item.Version, item.Namespace, item.Source}
+		if showAll {
+			row = append(row, fmt.Sprintf("%v", *item.Enabled))
 		}
+		rows = append(rows, row)
 	}
 	printTable(os.Stderr, headers, rows)
 	return nil

--- a/cmd/sikifanso/app_cmd.go
+++ b/cmd/sikifanso/app_cmd.go
@@ -270,7 +270,7 @@ func appListAction(_ context.Context, cmd *cli.Command, sess *session.Session) e
 	for _, item := range items {
 		row := []string{item.Name, item.Chart, item.Version, item.Namespace, item.Source}
 		if showAll {
-			row = append(row, fmt.Sprintf("%v", *item.Enabled))
+			row = append(row, fmt.Sprintf("%v", ptr.Deref(item.Enabled, false)))
 		}
 		rows = append(rows, row)
 	}


### PR DESCRIPTION
## Summary

- Adds `--all` / `-a` flag to `sikifanso app list` to show all catalog entries (enabled + disabled) alongside custom apps
- Without the flag, behavior is unchanged — only installed/enabled apps are shown
- With `--all`, an ENABLED column is added to the table and `enabled` field appears in JSON output
- Addresses PR #2 review feedback about silently dropped `catalog list` functionality

## Before / After

```
$ sikifanso app list                  # unchanged
NAME      CHART      VERSION  NAMESPACE  SOURCE
grafana   grafana    10.x     grafana    catalog

$ sikifanso app list --all            # new
NAME      CHART      VERSION  NAMESPACE  SOURCE   ENABLED
grafana   grafana    10.x     grafana    catalog  true
langfuse  langfuse   2.x      langfuse   catalog  false
```

## Test plan

- [x] `make build` passes
- [x] `make test` passes
- [x] `make lint` passes — 0 issues
- [ ] Manual: `sikifanso app list` shows only enabled apps (no regression)
- [ ] Manual: `sikifanso app list --all` shows full catalog with ENABLED column
- [ ] Manual: `sikifanso app list --all -o json` includes `enabled` field on all items

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

**[Linus Torvalds Mode]** Oh look, someone remembered to actually ship the feature they broke in PR #2 — I suppose we should hand out participation trophies now. The PR adds an `--all` / `-a` flag to `sikifanso app list`, extracting the old inline loops into a `buildAppListItems` helper that correctly gates catalog entries on `showAll || e.Enabled` and always marks custom apps as enabled. The previous nil-dereference concern raised in review has been addressed: the table rendering path now uses `ptr.Deref(item.Enabled, false)` instead of a naked `*item.Enabled`, so that footgun is gone.

Key changes:
- `appListCmd` gains a `--all` / `-a` `BoolFlag`; usage string updated to hint at the new behavior
- `buildAppListItems` centralises item construction for both JSON and table paths, removing the duplicated loops that existed before
- ENABLED column is appended to table headers and rows only when `showAll=true`; `omitempty` on the struct field keeps JSON clean in the default case
- Empty-state message updated from \"No apps installed\" to \"No apps found\" (accurate now that the command can query the full catalog)
- One trivial style nit: `fmt.Sprintf(\"%v\", bool)` on line 273 should be `strconv.FormatBool` — purely cosmetic, does not affect correctness

I'd say this is nearly merge-ready, but \"nearly\" is doing a lot of heavy lifting given the history of this feature.

<h3>Confidence Score: 5/5</h3>

**[Linus Torvalds Mode]** Remarkable — the code actually does what it says on the tin and doesn't panic. All remaining findings are P2 style nits that belong in a code-review footnote, not a blocker list; this is safe to merge.

I can't believe I'm typing this, but the nil-dereference that was going to blow up at 3 AM has been properly handled with `ptr.Deref`. The logic in `buildAppListItems` is straightforward and correct: custom apps are always shown, catalog entries are gated on `showAll || e.Enabled`, and the `Enabled` pointer is only populated when `showAll=true`, which keeps the JSON schema clean for the default case. The only surviving issue is using `fmt.Sprintf("%v", …)` to format a bool instead of `strconv.FormatBool` — that's a style gripe, not a bug. Apparently even a stopped clock is right twice a day.

Just the one file, `cmd/sikifanso/app_cmd.go`, and only for a petty formatting call on line 273 — if that's the worst thing here, I'm almost impressed.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/sikifanso/app_cmd.go | Adds `--all`/`-a` flag; extracts `buildAppListItems`; previous nil-deref concern is addressed with `ptr.Deref`; only trivial style nit remains |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[appListAction] --> B{showAll flag?}
    B -- false --> C[app.List]
    B -- true  --> C
    C --> D[catalog.List]
    D --> E[buildAppListItems]
    E --> F{for each custom app}
    F -- showAll=true  --> G[item.Enabled = ptr.To true]
    F -- showAll=false --> H[item.Enabled = nil]
    G --> I[append to items]
    H --> I
    E --> J{for each catalog entry}
    J -- showAll=true OR entry.Enabled --> K{showAll?}
    J -- showAll=false AND NOT entry.Enabled --> L[skip]
    K -- true  --> M[item.Enabled = ptr.To e.Enabled]
    K -- false --> N[item.Enabled = nil]
    M --> O[append to items]
    N --> O
    I --> P{output format?}
    O --> P
    P -- JSON --> Q[outputJSON items]
    P -- table --> R{len items == 0?}
    R -- yes --> S[print No apps found]
    R -- no  --> T{showAll?}
    T -- true  --> U[headers += ENABLED]
    T -- false --> V[headers unchanged]
    U --> W[build rows with ptr.Deref Enabled false]
    V --> X[build rows without ENABLED column]
    W --> Y[printTable]
    X --> Y
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: cmd/sikifanso/app_cmd.go
Line: 271-273

Comment:
**`fmt.Sprintf("%v", ...)` on a bool is unnecessary verbosity**

Did you raid the bottom of the Go standard library looking for the most roundabout way to stringify a bool? Congratulations, you found it.

`fmt.Sprintf("%v", someBool)` is a verbose detour to the same destination as `strconv.FormatBool`. Either that, or since only two values are ever possible, a ternary-style map or an explicit if/else is cleaner:

```suggestion
			row = append(row, strconv.FormatBool(ptr.Deref(item.Enabled, false)))
```

(Don't forget to add `"strconv"` to the import block.) You'll also want to remove the `fmt` import if it's no longer used elsewhere, though it clearly still is.

Anyway, it works — it just looks like you closed your eyes and grabbed the first formatting verb you could find.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: use ptr.Deref for defensive nil che..."](https://github.com/sikifanso/sikifanso/commit/55b3fc8c243ccd05a617b9b75a07e04c543ed261) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27314548)</sub>

<!-- /greptile_comment -->