### PR TITLE
feat: add cnpg-operator and alloy to profiles

### DIFF
--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -27,7 +27,7 @@ var registry = map[string]Profile{
 		Name:        "agent-full",
 		Description: "All AI agent infrastructure tools enabled",
 		Apps: []string{
-			"litellm-proxy", "langfuse", "prometheus-stack", "loki", "tempo",
+			"litellm-proxy", "langfuse", "prometheus-stack", "loki", "tempo", "alloy",
 			"guardrails-ai", "nemo-guardrails", "presidio",
 			"qdrant", "text-embeddings-inference", "unstructured",
 			"temporal", "external-secrets", "opa",
@@ -37,7 +37,7 @@ var registry = map[string]Profile{
 	"agent-dev": {
 		Name:        "agent-dev",
 		Description: "Local development loop with LLM, RAG, and observability",
-		Apps:        []string{"litellm-proxy", "ollama", "langfuse", "qdrant", "cnpg-operator", "postgresql", "valkey"},
+		Apps:        []string{"litellm-proxy", "ollama", "langfuse", "qdrant", "alloy", "cnpg-operator", "postgresql", "valkey"},
 	},
 	"agent-safe": {
 		Name:        "agent-safe",

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -37,7 +37,7 @@ var registry = map[string]Profile{
 	"agent-dev": {
 		Name:        "agent-dev",
 		Description: "Local development loop with LLM, RAG, and observability",
-		Apps:        []string{"litellm-proxy", "ollama", "langfuse", "qdrant", "alloy", "cnpg-operator", "postgresql", "valkey"},
+		Apps:        []string{"litellm-proxy", "ollama", "langfuse", "qdrant", "cnpg-operator", "postgresql", "valkey", "alloy"},
 	},
 	"agent-safe": {
 		Name:        "agent-safe",

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -21,7 +21,7 @@ var registry = map[string]Profile{
 	"agent-minimal": {
 		Name:        "agent-minimal",
 		Description: "Bare minimum to route and observe LLM calls",
-		Apps:        []string{"litellm-proxy", "langfuse", "postgresql"},
+		Apps:        []string{"litellm-proxy", "langfuse", "cnpg-operator", "postgresql"},
 	},
 	"agent-full": {
 		Name:        "agent-full",
@@ -31,26 +31,26 @@ var registry = map[string]Profile{
 			"guardrails-ai", "nemo-guardrails", "presidio",
 			"qdrant", "text-embeddings-inference", "unstructured",
 			"temporal", "external-secrets", "opa",
-			"ollama", "postgresql", "valkey",
+			"ollama", "cnpg-operator", "postgresql", "valkey",
 		},
 	},
 	"agent-dev": {
 		Name:        "agent-dev",
 		Description: "Local development loop with LLM, RAG, and observability",
-		Apps:        []string{"litellm-proxy", "ollama", "langfuse", "qdrant", "postgresql", "valkey"},
+		Apps:        []string{"litellm-proxy", "ollama", "langfuse", "qdrant", "cnpg-operator", "postgresql", "valkey"},
 	},
 	"agent-safe": {
 		Name:        "agent-safe",
 		Description: "Development stack with all guardrails and policy enforcement",
 		Apps: []string{
-			"litellm-proxy", "ollama", "langfuse", "qdrant", "postgresql", "valkey",
+			"litellm-proxy", "ollama", "langfuse", "qdrant", "cnpg-operator", "postgresql", "valkey",
 			"guardrails-ai", "nemo-guardrails", "presidio", "opa",
 		},
 	},
 	"rag": {
 		Name:        "rag",
 		Description: "RAG-focused stack with vector DB, embeddings, and document parsing",
-		Apps:        []string{"qdrant", "text-embeddings-inference", "unstructured", "postgresql"},
+		Apps:        []string{"qdrant", "text-embeddings-inference", "unstructured", "cnpg-operator", "postgresql"},
 	},
 }
 


### PR DESCRIPTION
## Summary

- Add `cnpg-operator` to all 5 PostgreSQL-dependent profiles
- Add `alloy` to `agent-full` and `agent-dev` profiles

Companion PR to sikifanso/sikifanso-homelab-bootstrap#20 (CNPG migration + Alloy).

## Test plan

- [ ] `make test` passes
- [ ] Profile resolution includes cnpg-operator before postgresql
- [ ] `agent-full` and `agent-dev` include alloy

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

**[Linus Torvalds Mode]** Oh good, someone figured out that a Kubernetes operator needs to exist before the resource it manages — congratulations on reading the CloudNativePG README. I'm genuinely moved that we're celebrating five string-slice edits as a pull request.

This PR adds `cnpg-operator` immediately before `postgresql` in all five PostgreSQL-dependent profiles (`agent-minimal`, `agent-full`, `agent-dev`, `agent-safe`, `rag`), and adds `alloy` to `agent-full` (sensibly grouped with `prometheus-stack`, `loki`, `tempo`) and `agent-dev` (inconsistently tacked on at the end rather than with the observability group). The `Apply()` function iterates apps in slice order and calls `catalog.SetEnabled` sequentially, so the position of `cnpg-operator` before `postgresql` is functionally correct across all profiles. The `Resolve()` deduplication logic correctly handles combined profiles. The one genuine gap is that the PR's own test plan promises to verify the ordering invariant but ships zero tests for it — meaning the constraint survives entirely on social contract until someone reorganizes a string slice.

- `cnpg-operator` correctly precedes `postgresql` in all 5 profiles
- `alloy` added to `agent-full` (observability group) and `agent-dev` (end of slice — inconsistent placement flagged separately)
- No test enforces the documented ordering invariant despite it appearing in the PR's own test plan

At least the code compiles — that bar, we cleared."

<h3>Confidence Score: 5/5</h3>

**[Linus Torvalds Mode]** Five string slices and a test plan that forgot to include tests — truly a heroic engineering achievement. Safe to merge; nothing here will catch fire.

I've seen more ambitious changes in a README typo fix. The entire diff is five `Apps` slice edits. No P0 or P1 issues: the ordering invariant (cnpg-operator before postgresql) is correctly maintained in all five profiles, `Resolve()` deduplication is unaffected, and `Apply()` iteration order is preserved. The only findings are P2 — an inconsistent `alloy` placement in `agent-dev` (already flagged) and a missing test for the documented ordering invariant. Neither blocks correctness. Five out of five, though I feel slightly embarrassed giving that score.

Only `internal/profile/profile.go` touched. It's five string-slice edits dressed up as an operator migration — try not to trip over it.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/profile/profile.go | Adds cnpg-operator before postgresql in all 5 profiles and alloy to agent-full/agent-dev; ordering invariant is correct in all cases but the PR's own test plan item has no corresponding test |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Resolve(profileStr)"] --> B["Split by comma"]
    B --> C["For each profile name"]
    C --> D["registry lookup via Get()"]
    D --> E["Deduplicate apps\n(seen map preserves first-occurrence order)"]
    E --> F["Return ordered app slice"]
    F --> G["Apply(gitOpsPath, profileName, apps)"]
    G --> H["For each app in order"]
    H --> I{"catalog.SetEnabled?"}
    I -- success --> J["Append to committed list"]
    I -- "error: file missing" --> K["warn() and skip"]
    J --> H
    K --> H
    H --> L["gitops.Commit(files...)"]
    L --> M["Done"]

    subgraph order ["Ordering Invariant — all 5 profiles"]
      N["cnpg-operator"] -->|must precede| O["postgresql"]
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/profile/profile.go
Line: 20-55

Comment:
**Test Plan Written, Tests Missing**

You put "Profile resolution includes cnpg-operator before postgresql" in your test plan and then just didn't write it. The audacity is genuinely impressive.

The PR's own test plan bullet has no corresponding test in `profile_test.go`. `TestResolve_CompositeProfile` checks deduplication, not ordering — these are different properties. A future contributor can silently swap `cnpg-operator` and `postgresql` in any of the five affected profiles and nothing will catch it. A self-maintaining invariant test that iterates the registry handles all five profiles at once and covers any future additions:

```go
func TestRegistry_CnpgOperatorBeforePostgresql(t *testing.T) {
    for name, p := range registry {
        cnpgIdx, pgIdx := -1, -1
        for i, app := range p.Apps {
            if app == "cnpg-operator" { cnpgIdx = i }
            if app == "postgresql"    { pgIdx = i }
        }
        if cnpgIdx != -1 && pgIdx != -1 && cnpgIdx >= pgIdx {
            t.Errorf("profile %q: cnpg-operator (idx %d) must precede postgresql (idx %d)", name, cnpgIdx, pgIdx)
        }
    }
}
```

Write the test you promised, or remove the bullet point — pick one.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>**[Greploops](https://www.greptile.com/docs/mcp-v2/skills#greploop)** — Automatically fix all review issues by running `/greploops` in [Claude Code](https://claude.ai/download). It iterates: fix, push, re-review, repeat until 5/5 confidence.<br>Use the **[Greptile plugin for Claude Code](https://www.greptile.com/docs/integrations/claude-code#claude-code-plugin)** to query reviews, search comments, and manage custom context directly from your terminal.</sub>

<sub>Reviews (2): Last reviewed commit: ["fix: move alloy to end of agent-dev prof..."](https://github.com/sikifanso/sikifanso/commit/5ec9b77abfe2d5b7401891fc9c30cf7c78213891) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27351267)</sub>

<!-- /greptile_comment -->