### PR TITLE
feat: catalog app sync ordering via RollingSync + dependency graph

### DIFF
--- a/cmd/sikifanso/app_cmd.go
+++ b/cmd/sikifanso/app_cmd.go
@@ -320,7 +320,10 @@ func appDisableCmd() *cli.Command {
 		Name:      "disable",
 		Usage:     "Disable a catalog application",
 		ArgsUsage: "NAME",
-		Flags:     waitSyncFlags(),
+		Flags: append(waitSyncFlags(), &cli.BoolFlag{
+			Name:  "force",
+			Usage: "Bypass dependent-app safety check",
+		}),
 		Action: withSession(func(ctx context.Context, cmd *cli.Command, sess *session.Session) error {
 			return appToggleAction(ctx, cmd, sess, false)
 		}),
@@ -341,7 +344,8 @@ func appToggleAction(ctx context.Context, cmd *cli.Command, sess *session.Sessio
 		return fmt.Errorf("app name is required: sikifanso app %s NAME", verb)
 	}
 
-	result, err := catalog.Toggle(sess.GitOpsPath, name, enable)
+	force := cmd.Bool("force")
+	result, err := catalog.ToggleWithDeps(sess.GitOpsPath, name, enable, force)
 	if err != nil {
 		return err
 	}
@@ -350,15 +354,25 @@ func appToggleAction(ctx context.Context, cmd *cli.Command, sess *session.Sessio
 		return nil
 	}
 
+	if len(result.AutoDeps) > 0 {
+		fmt.Fprintf(os.Stderr, "auto-enabled: %s\n", strings.Join(result.AutoDeps, ", "))
+	}
+
 	fmt.Fprintf(os.Stderr, "%s committed to gitops repo\n", name)
 
 	op := grpcsync.OpEnable
 	if !enable {
 		op = grpcsync.OpDisable
 	}
+
+	syncApps := []string{name}
+	if len(result.AutoDeps) > 0 {
+		syncApps = append(result.AutoDeps, name)
+	}
+
 	if err := syncAfterMutation(ctx, cmd, sess, MutationOpts{
 		Operation:  op,
-		Apps:       []string{name},
+		Apps:       syncApps,
 		AppSetName: "catalog",
 	}); err != nil {
 		return err

--- a/cmd/sikifanso/app_cmd.go
+++ b/cmd/sikifanso/app_cmd.go
@@ -344,7 +344,7 @@ func appToggleAction(ctx context.Context, cmd *cli.Command, sess *session.Sessio
 		return fmt.Errorf("app name is required: sikifanso app %s NAME", verb)
 	}
 
-	force := cmd.Bool("force")
+	force := !enable && cmd.Bool("force")
 	result, err := catalog.ToggleWithDeps(sess.GitOpsPath, name, enable, force)
 	if err != nil {
 		return err

--- a/cmd/sikifanso/app_cmd.go
+++ b/cmd/sikifanso/app_cmd.go
@@ -367,7 +367,7 @@ func appToggleAction(ctx context.Context, cmd *cli.Command, sess *session.Sessio
 
 	syncApps := []string{name}
 	if len(result.AutoDeps) > 0 {
-		syncApps = append(result.AutoDeps, name)
+		syncApps = append(append([]string{}, result.AutoDeps...), name)
 	}
 
 	if err := syncAfterMutation(ctx, cmd, sess, MutationOpts{

--- a/cmd/sikifanso/cluster_create.go
+++ b/cmd/sikifanso/cluster_create.go
@@ -92,10 +92,14 @@ func clusterCreateAction(ctx context.Context, cmd *cli.Command) error {
 	// Apply profile after cluster creation — enables catalog apps and commits.
 	if len(profileApps) > 0 {
 		zapLogger.Info("applying profile", zap.String("profile", profileStr), zap.Strings("apps", profileApps))
-		if err := profile.Apply(sess.GitOpsPath, profileStr, profileApps, func(msg string) {
+		autoAdded, err := profile.Apply(sess.GitOpsPath, profileStr, profileApps, func(msg string) {
 			zapLogger.Warn(msg)
-		}); err != nil {
+		})
+		if err != nil {
 			return fmt.Errorf("applying profile: %w", err)
+		}
+		if len(autoAdded) > 0 {
+			zapLogger.Info("auto-enabled dependencies", zap.Strings("deps", autoAdded))
 		}
 		// Trigger ArgoCD sync so enabled apps deploy immediately.
 		client, connErr := grpcclient.FromSessionCreds(ctx,

--- a/docs/superpowers/plans/2026-04-04-rolling-sync-depgraph.md
+++ b/docs/superpowers/plans/2026-04-04-rolling-sync-depgraph.md
@@ -1,0 +1,1099 @@
+# Rolling Sync + Dependency Graph Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix catalog app sync ordering so CRD-dependent apps (e.g. postgresql) wait for their operators (e.g. cnpg-operator) before syncing, both server-side (ArgoCD RollingSync) and CLI-side (dependency resolution on enable/disable).
+
+**Architecture:** Two complementary mechanisms: (1) ArgoCD ApplicationSet RollingSync groups apps into ordered tiers via labels — tier 0 operators sync first, then tier 1 data, then tier 2 services, then unmatched apps last. (2) CLI-side dependency graph auto-enables transitive deps on `app enable` and blocks unsafe `app disable` unless `--force` is passed. Profile `Apply` resolves transitive deps before enabling.
+
+**Tech Stack:** Go 1.25+, urfave/cli/v3, ArgoCD ApplicationSet v2.6+ (RollingSync/progressive syncs), sigs.k8s.io/yaml, gopkg.in/yaml.v3
+
+**Spec:** `docs/superpowers/specs/2026-04-04-rolling-sync-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `internal/catalog/catalog.go` | Modify | Add `Tier` and `DependsOn` fields to `Entry` struct |
+| `internal/catalog/depgraph.go` | Create | `ResolveDeps`, `Dependents`, cycle detection |
+| `internal/catalog/depgraph_test.go` | Create | Tests for dependency graph functions |
+| `internal/catalog/service.go` | Modify | Add `ToggleWithDeps` alongside existing `Toggle` |
+| `cmd/sikifanso/app_cmd.go` | Modify | Wire `ToggleWithDeps`, add `--force` flag to disable |
+| `internal/profile/profile.go` | Modify | `Apply` returns `([]string, error)` with auto-added deps |
+| `cmd/sikifanso/cluster_create.go` | Modify | Handle updated `Apply` return signature |
+| `internal/mcp/helpers.go` | Modify | Handle updated `Apply` return signature |
+| `internal/mcp/catalog.go` | Modify | Use `ToggleWithDeps` instead of `Toggle` |
+| `internal/infraconfig/defaults/argocd-values.yaml` | Modify | Add `--enable-progressive-syncs` arg |
+| `../sikifanso-homelab-bootstrap/bootstrap/root-catalog.yaml` | Modify | RollingSync strategy + tier label |
+| `../sikifanso-homelab-bootstrap/catalog/*.yaml` (19 files) | Modify | Add `tier` and `dependsOn` fields |
+
+---
+
+### Task 1: Add Tier and DependsOn Fields to Entry Struct
+
+**Files:**
+- Modify: `internal/catalog/catalog.go:16-25`
+
+- [ ] **Step 1: Add the two new fields to Entry**
+
+In `internal/catalog/catalog.go`, add `Tier` and `DependsOn` after the `Enabled` field (line 24):
+
+```go
+type Entry struct {
+	Name           string   `json:"name"`
+	Category       string   `json:"category"`
+	Description    string   `json:"description"`
+	RepoURL        string   `json:"repoURL"`
+	Chart          string   `json:"chart"`
+	TargetRevision string   `json:"targetRevision"`
+	Namespace      string   `json:"namespace"`
+	Enabled        bool     `json:"enabled"`
+	Tier           string   `json:"tier,omitempty"`
+	DependsOn      []string `json:"dependsOn,omitempty"`
+}
+```
+
+- [ ] **Step 2: Run existing tests to verify backward compatibility**
+
+Run: `cd sikifanso && go test ./internal/catalog/ -race -v`
+Expected: All 10 existing tests PASS (omitempty means existing YAML without these fields still parses correctly)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/catalog/catalog.go
+git commit -m "catalog: add Tier and DependsOn fields to Entry"
+```
+
+---
+
+### Task 2: Implement Dependency Graph
+
+**Files:**
+- Create: `internal/catalog/depgraph.go`
+- Create: `internal/catalog/depgraph_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/catalog/depgraph_test.go`:
+
+```go
+package catalog
+
+import (
+	"testing"
+)
+
+func TestResolveDeps_NoDeps(t *testing.T) {
+	t.Parallel()
+	all := []Entry{
+		{Name: "ollama"},
+		{Name: "qdrant"},
+	}
+	resolved, autoAdded, err := ResolveDeps([]string{"ollama"}, all)
+	if err != nil {
+		t.Fatalf("ResolveDeps: %v", err)
+	}
+	if len(resolved) != 1 || resolved[0] != "ollama" {
+		t.Errorf("resolved = %v, want [ollama]", resolved)
+	}
+	if len(autoAdded) != 0 {
+		t.Errorf("autoAdded = %v, want empty", autoAdded)
+	}
+}
+
+func TestResolveDeps_DirectDeps(t *testing.T) {
+	t.Parallel()
+	all := []Entry{
+		{Name: "cnpg-operator"},
+		{Name: "prometheus-stack"},
+		{Name: "postgresql", DependsOn: []string{"cnpg-operator", "prometheus-stack"}},
+	}
+	resolved, autoAdded, err := ResolveDeps([]string{"postgresql"}, all)
+	if err != nil {
+		t.Fatalf("ResolveDeps: %v", err)
+	}
+	// Deps must come before the requested app.
+	if len(resolved) != 3 {
+		t.Fatalf("resolved = %v, want 3 entries", resolved)
+	}
+	// postgresql must be last.
+	if resolved[len(resolved)-1] != "postgresql" {
+		t.Errorf("last resolved = %q, want postgresql", resolved[len(resolved)-1])
+	}
+	if len(autoAdded) != 2 {
+		t.Errorf("autoAdded = %v, want 2 entries", autoAdded)
+	}
+}
+
+func TestResolveDeps_TransitiveDeps(t *testing.T) {
+	t.Parallel()
+	all := []Entry{
+		{Name: "cnpg-operator"},
+		{Name: "prometheus-stack"},
+		{Name: "postgresql", DependsOn: []string{"cnpg-operator", "prometheus-stack"}},
+		{Name: "langfuse", DependsOn: []string{"cnpg-operator", "postgresql"}},
+	}
+	resolved, autoAdded, err := ResolveDeps([]string{"langfuse"}, all)
+	if err != nil {
+		t.Fatalf("ResolveDeps: %v", err)
+	}
+	// Must include: cnpg-operator, prometheus-stack (transitive via postgresql), postgresql, langfuse.
+	if len(resolved) != 4 {
+		t.Fatalf("resolved = %v, want 4 entries", resolved)
+	}
+	if resolved[len(resolved)-1] != "langfuse" {
+		t.Errorf("last resolved = %q, want langfuse", resolved[len(resolved)-1])
+	}
+	if len(autoAdded) != 3 {
+		t.Errorf("autoAdded = %v, want 3 entries", autoAdded)
+	}
+}
+
+func TestResolveDeps_AlreadyRequested(t *testing.T) {
+	t.Parallel()
+	all := []Entry{
+		{Name: "cnpg-operator"},
+		{Name: "postgresql", DependsOn: []string{"cnpg-operator"}},
+	}
+	// If cnpg-operator is already in the requested list, it should not appear in autoAdded.
+	resolved, autoAdded, err := ResolveDeps([]string{"cnpg-operator", "postgresql"}, all)
+	if err != nil {
+		t.Fatalf("ResolveDeps: %v", err)
+	}
+	if len(resolved) != 2 {
+		t.Fatalf("resolved = %v, want 2 entries", resolved)
+	}
+	if len(autoAdded) != 0 {
+		t.Errorf("autoAdded = %v, want empty (both were requested)", autoAdded)
+	}
+}
+
+func TestResolveDeps_CycleDetection(t *testing.T) {
+	t.Parallel()
+	all := []Entry{
+		{Name: "a", DependsOn: []string{"b"}},
+		{Name: "b", DependsOn: []string{"a"}},
+	}
+	_, _, err := ResolveDeps([]string{"a"}, all)
+	if err == nil {
+		t.Fatal("expected cycle error, got nil")
+	}
+}
+
+func TestResolveDeps_UnknownDep(t *testing.T) {
+	t.Parallel()
+	all := []Entry{
+		{Name: "postgresql", DependsOn: []string{"nonexistent"}},
+	}
+	_, _, err := ResolveDeps([]string{"postgresql"}, all)
+	if err == nil {
+		t.Fatal("expected error for unknown dep, got nil")
+	}
+}
+
+func TestDependents_Direct(t *testing.T) {
+	t.Parallel()
+	all := []Entry{
+		{Name: "cnpg-operator", Enabled: true},
+		{Name: "postgresql", Enabled: true, DependsOn: []string{"cnpg-operator", "prometheus-stack"}},
+		{Name: "langfuse", Enabled: true, DependsOn: []string{"cnpg-operator", "postgresql"}},
+		{Name: "ollama", Enabled: true},
+	}
+	deps := Dependents("cnpg-operator", all)
+	if len(deps) != 2 {
+		t.Fatalf("Dependents = %v, want 2 entries (postgresql, langfuse)", deps)
+	}
+}
+
+func TestDependents_OnlyEnabled(t *testing.T) {
+	t.Parallel()
+	all := []Entry{
+		{Name: "cnpg-operator", Enabled: true},
+		{Name: "postgresql", Enabled: false, DependsOn: []string{"cnpg-operator"}},
+	}
+	deps := Dependents("cnpg-operator", all)
+	if len(deps) != 0 {
+		t.Errorf("Dependents = %v, want empty (postgresql is disabled)", deps)
+	}
+}
+
+func TestDependents_NoDependents(t *testing.T) {
+	t.Parallel()
+	all := []Entry{
+		{Name: "ollama", Enabled: true},
+		{Name: "qdrant", Enabled: true},
+	}
+	deps := Dependents("ollama", all)
+	if len(deps) != 0 {
+		t.Errorf("Dependents = %v, want empty", deps)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd sikifanso && go test ./internal/catalog/ -run TestResolveDeps -race -v`
+Expected: FAIL — `ResolveDeps` undefined
+
+- [ ] **Step 3: Implement depgraph.go**
+
+Create `internal/catalog/depgraph.go`:
+
+```go
+package catalog
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ResolveDeps performs BFS transitive dependency resolution. Given a set of
+// requested app names and all catalog entries, it returns:
+//   - resolved: the full ordered set (deps before dependents)
+//   - autoAdded: names that were not in the original requested set
+//
+// Returns an error if a cycle is detected or a dependency does not exist.
+func ResolveDeps(requested []string, all []Entry) (resolved, autoAdded []string, err error) {
+	byName := make(map[string]Entry, len(all))
+	for _, e := range all {
+		byName[e.Name] = e
+	}
+
+	requestedSet := make(map[string]bool, len(requested))
+	for _, name := range requested {
+		requestedSet[name] = true
+	}
+
+	// BFS with cycle detection via "visiting" state.
+	const (
+		unvisited = 0
+		visiting  = 1
+		visited   = 2
+	)
+	state := make(map[string]int)
+	var order []string
+
+	var visit func(name string, path []string) error
+	visit = func(name string, path []string) error {
+		switch state[name] {
+		case visited:
+			return nil
+		case visiting:
+			return fmt.Errorf("dependency cycle detected: %s -> %s", strings.Join(path, " -> "), name)
+		}
+
+		entry, ok := byName[name]
+		if !ok {
+			return fmt.Errorf("dependency %q not found in catalog", name)
+		}
+
+		state[name] = visiting
+		for _, dep := range entry.DependsOn {
+			if err := visit(dep, append(path, name)); err != nil {
+				return err
+			}
+		}
+		state[name] = visited
+		order = append(order, name)
+		return nil
+	}
+
+	for _, name := range requested {
+		if err := visit(name, nil); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	// Determine which were auto-added (in order but not originally requested).
+	var added []string
+	for _, name := range order {
+		if !requestedSet[name] {
+			added = append(added, name)
+		}
+	}
+
+	return order, added, nil
+}
+
+// Dependents returns the names of enabled entries that directly depend on the
+// given app name. The result is sorted for deterministic output.
+func Dependents(name string, all []Entry) []string {
+	var deps []string
+	for _, e := range all {
+		if !e.Enabled {
+			continue
+		}
+		for _, d := range e.DependsOn {
+			if d == name {
+				deps = append(deps, e.Name)
+				break
+			}
+		}
+	}
+	sort.Strings(deps)
+	return deps
+}
+```
+
+- [ ] **Step 4: Run all depgraph tests**
+
+Run: `cd sikifanso && go test ./internal/catalog/ -run "TestResolveDeps|TestDependents" -race -v`
+Expected: All 9 tests PASS
+
+- [ ] **Step 5: Run full catalog test suite**
+
+Run: `cd sikifanso && go test ./internal/catalog/ -race -v`
+Expected: All tests PASS (existing + new)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/catalog/depgraph.go internal/catalog/depgraph_test.go
+git commit -m "catalog: add dependency graph with BFS resolution and cycle detection"
+```
+
+---
+
+### Task 3: Add ToggleWithDeps to Service Layer
+
+**Files:**
+- Modify: `internal/catalog/service.go`
+
+- [ ] **Step 1: Add ToggleWithDepsResult type and ToggleWithDeps function**
+
+Add below the existing `Flip` function (after line 59) in `internal/catalog/service.go`:
+
+```go
+// ToggleWithDepsResult describes the outcome of a ToggleWithDeps operation.
+type ToggleWithDepsResult struct {
+	Name      string
+	Enabled   bool
+	NoChange  bool
+	AutoDeps  []string // dep names that were auto-enabled (enable path only)
+}
+
+// ToggleWithDeps is like Toggle but resolves transitive dependencies.
+//
+// Enable path: auto-enables missing dependencies, commits all changes together.
+// Disable path: returns error listing dependents unless force is true.
+// Force bypasses the dependent check but does NOT cascade-disable dependents.
+func ToggleWithDeps(gitOpsPath, name string, enable, force bool) (*ToggleWithDepsResult, error) {
+	entry, err := Find(gitOpsPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if entry.Enabled == enable {
+		return &ToggleWithDepsResult{Name: name, Enabled: enable, NoChange: true}, nil
+	}
+
+	if enable {
+		return toggleWithDepsEnable(gitOpsPath, name)
+	}
+	return toggleWithDepsDisable(gitOpsPath, name, force)
+}
+
+func toggleWithDepsEnable(gitOpsPath, name string) (*ToggleWithDepsResult, error) {
+	all, err := List(gitOpsPath)
+	if err != nil {
+		return nil, fmt.Errorf("listing catalog: %w", err)
+	}
+
+	resolved, autoAdded, err := ResolveDeps([]string{name}, all)
+	if err != nil {
+		return nil, fmt.Errorf("resolving dependencies: %w", err)
+	}
+
+	// Build a map of currently enabled entries to skip no-ops.
+	enabledSet := make(map[string]bool, len(all))
+	for _, e := range all {
+		if e.Enabled {
+			enabledSet[e.Name] = true
+		}
+	}
+
+	var commitPaths []string
+	var actualAutoAdded []string
+	for _, app := range resolved {
+		if enabledSet[app] {
+			continue // already enabled
+		}
+		if err := SetEnabled(gitOpsPath, app, true); err != nil {
+			return nil, fmt.Errorf("enabling %s: %w", app, err)
+		}
+		commitPaths = append(commitPaths, fmt.Sprintf("catalog/%s.yaml", app))
+		if app != name {
+			actualAutoAdded = append(actualAutoAdded, app)
+		}
+	}
+
+	if len(commitPaths) > 0 {
+		commitMsg := fmt.Sprintf("catalog: enable %s", name)
+		if len(actualAutoAdded) > 0 {
+			commitMsg += fmt.Sprintf(" (auto-deps: %s)", strings.Join(actualAutoAdded, ", "))
+		}
+		if err := gitops.Commit(gitOpsPath, commitMsg, commitPaths...); err != nil {
+			return nil, fmt.Errorf("committing changes: %w", err)
+		}
+	}
+
+	return &ToggleWithDepsResult{
+		Name:     name,
+		Enabled:  true,
+		AutoDeps: actualAutoAdded,
+	}, nil
+}
+
+func toggleWithDepsDisable(gitOpsPath, name string, force bool) (*ToggleWithDepsResult, error) {
+	if !force {
+		all, err := List(gitOpsPath)
+		if err != nil {
+			return nil, fmt.Errorf("listing catalog: %w", err)
+		}
+		deps := Dependents(name, all)
+		if len(deps) > 0 {
+			return nil, fmt.Errorf("cannot disable %s: required by %s (use --force to override)", name, strings.Join(deps, ", "))
+		}
+	}
+
+	if err := SetEnabled(gitOpsPath, name, false); err != nil {
+		return nil, fmt.Errorf("disabling %s: %w", name, err)
+	}
+
+	commitMsg := fmt.Sprintf("catalog: disable %s", name)
+	commitPath := fmt.Sprintf("catalog/%s.yaml", name)
+	if err := gitops.Commit(gitOpsPath, commitMsg, commitPath); err != nil {
+		return nil, fmt.Errorf("committing change: %w", err)
+	}
+
+	return &ToggleWithDepsResult{Name: name, Enabled: false}, nil
+}
+```
+
+Also add `"strings"` to the import block at the top of `service.go`:
+
+```go
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alicanalbayrak/sikifanso/internal/gitops"
+)
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `cd sikifanso && go build ./internal/catalog/`
+Expected: Success
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `cd sikifanso && go test ./internal/catalog/ -race -v`
+Expected: All tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/catalog/service.go
+git commit -m "catalog: add ToggleWithDeps with dependency resolution and disable guard"
+```
+
+---
+
+### Task 4: Wire CLI to Use ToggleWithDeps
+
+**Files:**
+- Modify: `cmd/sikifanso/app_cmd.go:318-369`
+
+- [ ] **Step 1: Add --force flag to appDisableCmd**
+
+In `cmd/sikifanso/app_cmd.go`, replace the `appDisableCmd` function (lines 318-329):
+
+```go
+func appDisableCmd() *cli.Command {
+	return &cli.Command{
+		Name:      "disable",
+		Usage:     "Disable a catalog application",
+		ArgsUsage: "NAME",
+		Flags: append(waitSyncFlags(), &cli.BoolFlag{
+			Name:  "force",
+			Usage: "Bypass dependent-app safety check",
+		}),
+		Action: withSession(func(ctx context.Context, cmd *cli.Command, sess *session.Session) error {
+			return appToggleAction(ctx, cmd, sess, false)
+		}),
+		ShellComplete: catalogEnabledNamesComplete,
+	}
+}
+```
+
+- [ ] **Step 2: Replace catalog.Toggle with catalog.ToggleWithDeps in appToggleAction**
+
+Replace the `appToggleAction` function body (lines 331-369):
+
+```go
+func appToggleAction(ctx context.Context, cmd *cli.Command, sess *session.Session, enable bool) error {
+	verb := "enable"
+	past := "enabled"
+	if !enable {
+		verb = "disable"
+		past = "disabled"
+	}
+
+	name := cmd.Args().First()
+	if name == "" {
+		return fmt.Errorf("app name is required: sikifanso app %s NAME", verb)
+	}
+
+	force := cmd.Bool("force")
+	result, err := catalog.ToggleWithDeps(sess.GitOpsPath, name, enable, force)
+	if err != nil {
+		return err
+	}
+	if result.NoChange {
+		fmt.Fprintf(os.Stderr, "%s is already %s\n", name, past)
+		return nil
+	}
+
+	if len(result.AutoDeps) > 0 {
+		fmt.Fprintf(os.Stderr, "auto-enabled: %s\n", strings.Join(result.AutoDeps, ", "))
+	}
+
+	fmt.Fprintf(os.Stderr, "%s committed to gitops repo\n", name)
+
+	op := grpcsync.OpEnable
+	if !enable {
+		op = grpcsync.OpDisable
+	}
+
+	syncApps := []string{name}
+	if len(result.AutoDeps) > 0 {
+		syncApps = append(result.AutoDeps, name)
+	}
+
+	if err := syncAfterMutation(ctx, cmd, sess, MutationOpts{
+		Operation:  op,
+		Apps:       syncApps,
+		AppSetName: "catalog",
+	}); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "%s %s ✓\n", color.GreenString(name), past)
+	return nil
+}
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cd sikifanso && go build ./cmd/sikifanso/`
+Expected: Success
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/sikifanso/app_cmd.go
+git commit -m "cli: wire ToggleWithDeps for app enable/disable with --force flag"
+```
+
+---
+
+### Task 5: Update Profile Apply to Return Auto-Added Deps
+
+**Files:**
+- Modify: `internal/profile/profile.go:112-130`
+
+- [ ] **Step 1: Change Apply signature and add dependency resolution**
+
+Replace the `Apply` function (lines 112-130) in `internal/profile/profile.go`:
+
+```go
+// Apply enables the given apps in the catalog at gitOpsPath and commits the
+// changes in a single commit. Transitive dependencies are resolved and
+// auto-enabled. Returns the names of auto-added dependencies.
+//
+// Apps that don't exist in the catalog are skipped with a warning via the
+// provided warn function. The profileName is used in the commit message.
+func Apply(gitOpsPath string, profileName string, apps []string, warn func(string)) ([]string, error) {
+	all, err := catalog.List(gitOpsPath)
+	if err != nil {
+		return nil, fmt.Errorf("listing catalog: %w", err)
+	}
+
+	resolved, autoAdded, err := catalog.ResolveDeps(apps, all)
+	if err != nil {
+		return nil, fmt.Errorf("resolving dependencies: %w", err)
+	}
+
+	var committed []string
+	for _, app := range resolved {
+		if err := catalog.SetEnabled(gitOpsPath, app, true); err != nil {
+			if warn != nil {
+				warn(fmt.Sprintf("skipping %s: %s", app, err))
+			}
+			continue
+		}
+		committed = append(committed, fmt.Sprintf("catalog/%s.yaml", app))
+	}
+
+	if len(committed) == 0 {
+		return nil, nil
+	}
+
+	msg := fmt.Sprintf("profile: enable %s apps", profileName)
+	if err := gitops.Commit(gitOpsPath, msg, committed...); err != nil {
+		return nil, err
+	}
+	return autoAdded, nil
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `cd sikifanso && go build ./internal/profile/`
+Expected: FAIL — callers of `Apply` don't handle the new return value yet. That's expected; we fix them in the next steps.
+
+- [ ] **Step 3: Commit (partial — callers updated in next tasks)**
+
+```bash
+git add internal/profile/profile.go
+git commit -m "profile: resolve transitive deps in Apply, return auto-added list"
+```
+
+---
+
+### Task 6: Update Apply Call Sites
+
+**Files:**
+- Modify: `cmd/sikifanso/cluster_create.go:95`
+- Modify: `internal/mcp/helpers.go:76`
+
+- [ ] **Step 1: Update cluster_create.go**
+
+In `cmd/sikifanso/cluster_create.go`, replace lines 95-99:
+
+Old:
+```go
+		if err := profile.Apply(sess.GitOpsPath, profileStr, profileApps, func(msg string) {
+			zapLogger.Warn(msg)
+		}); err != nil {
+			return fmt.Errorf("applying profile: %w", err)
+		}
+```
+
+New:
+```go
+		autoAdded, err := profile.Apply(sess.GitOpsPath, profileStr, profileApps, func(msg string) {
+			zapLogger.Warn(msg)
+		})
+		if err != nil {
+			return fmt.Errorf("applying profile: %w", err)
+		}
+		if len(autoAdded) > 0 {
+			zapLogger.Info("auto-enabled dependencies", zap.Strings("deps", autoAdded))
+		}
+```
+
+- [ ] **Step 2: Update mcp/helpers.go**
+
+In `internal/mcp/helpers.go`, replace lines 75-85:
+
+Old:
+```go
+	var warnings []string
+	if err := profile.Apply(sess.GitOpsPath, profileName, apps, func(msg string) {
+		warnings = append(warnings, msg)
+	}); err != nil {
+		return "", fmt.Errorf("applying profile %q: %w", profileName, err)
+	}
+
+	result := fmt.Sprintf("Profile %q applied (%d apps enabled).", profileName, len(apps))
+	for _, w := range warnings {
+		result += fmt.Sprintf("\n  Warning: %s", w)
+	}
+```
+
+New:
+```go
+	var warnings []string
+	autoAdded, err := profile.Apply(sess.GitOpsPath, profileName, apps, func(msg string) {
+		warnings = append(warnings, msg)
+	})
+	if err != nil {
+		return "", fmt.Errorf("applying profile %q: %w", profileName, err)
+	}
+
+	result := fmt.Sprintf("Profile %q applied (%d apps enabled).", profileName, len(apps))
+	if len(autoAdded) > 0 {
+		result += fmt.Sprintf("\n  Auto-enabled dependencies: %s", strings.Join(autoAdded, ", "))
+	}
+	for _, w := range warnings {
+		result += fmt.Sprintf("\n  Warning: %s", w)
+	}
+```
+
+Also add `"strings"` to the import block of `internal/mcp/helpers.go` if not already present.
+
+- [ ] **Step 3: Verify full build**
+
+Run: `cd sikifanso && go build ./...`
+Expected: Success — all callers now handle the updated return type
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/sikifanso/cluster_create.go internal/mcp/helpers.go
+git commit -m "cli/mcp: handle updated profile.Apply return with auto-added deps"
+```
+
+---
+
+### Task 7: Update MCP Catalog Toggle
+
+**Files:**
+- Modify: `internal/mcp/catalog.go:102-123`
+
+- [ ] **Step 1: Replace catalog.Toggle with catalog.ToggleWithDeps**
+
+In `internal/mcp/catalog.go`, replace the `catalogToggle` function (lines 102-123):
+
+```go
+func catalogToggle(ctx context.Context, deps *Deps, clusterName, appName string, enable bool) (*mcp.CallToolResult, any, error) {
+	past := "enabled"
+	if !enable {
+		past = "disabled"
+	}
+
+	sess, r, sv, e := loadSession(clusterName)
+	if sess == nil {
+		return r, sv, e
+	}
+
+	// MCP has no --force equivalent — agents must disable dependents explicitly.
+	result, err := catalog.ToggleWithDeps(sess.GitOpsPath, appName, enable, false)
+	if err != nil {
+		return errResult(err)
+	}
+	if result.NoChange {
+		return textResult(fmt.Sprintf("%s is already %s.", appName, past))
+	}
+
+	msg := fmt.Sprintf("%s %s and committed to gitops repo.", appName, past)
+	if len(result.AutoDeps) > 0 {
+		msg += fmt.Sprintf(" Auto-enabled dependencies: %s.", strings.Join(result.AutoDeps, ", "))
+	}
+	return textResult(appendSyncStatus(ctx, deps, sess, msg, "catalog"))
+}
+```
+
+Also add `"strings"` to the import block of `internal/mcp/catalog.go` if not already present.
+
+- [ ] **Step 2: Verify build**
+
+Run: `cd sikifanso && go build ./...`
+Expected: Success
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/mcp/catalog.go
+git commit -m "mcp: use ToggleWithDeps for catalog enable/disable"
+```
+
+---
+
+### Task 8: Enable Progressive Syncs in ArgoCD Config
+
+**Files:**
+- Modify: `internal/infraconfig/defaults/argocd-values.yaml:74-84`
+
+- [ ] **Step 1: Add --enable-progressive-syncs flag**
+
+In `internal/infraconfig/defaults/argocd-values.yaml`, replace lines 74-84:
+
+Old:
+```yaml
+applicationSet:
+  enabled: true
+  extraArgs:
+    - "--repo-server-plaintext"
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+```
+
+New:
+```yaml
+applicationSet:
+  enabled: true
+  extraArgs:
+    - "--repo-server-plaintext"
+    - "--enable-progressive-syncs"
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+```
+
+- [ ] **Step 2: Verify build (embeds this file)**
+
+Run: `cd sikifanso && go build ./...`
+Expected: Success
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/infraconfig/defaults/argocd-values.yaml
+git commit -m "argocd: enable progressive syncs for ApplicationSet RollingSync"
+```
+
+---
+
+### Task 9: Update root-catalog.yaml to RollingSync Strategy
+
+**Files:**
+- Modify: `../sikifanso-homelab-bootstrap/bootstrap/root-catalog.yaml`
+
+- [ ] **Step 1: Rewrite root-catalog.yaml**
+
+Replace the entire content of `sikifanso-homelab-bootstrap/bootstrap/root-catalog.yaml`:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: catalog
+  namespace: argocd
+spec:
+  strategy:
+    type: RollingSync
+    rollingSync:
+      steps:
+        - matchExpressions:
+            - key: tier
+              operator: In
+              values:
+                - 0-operators
+        - matchExpressions:
+            - key: tier
+              operator: In
+              values:
+                - 1-data
+        - matchExpressions:
+            - key: tier
+              operator: In
+              values:
+                - 2-services
+  generators:
+    - git:
+        repoURL: /local-gitops
+        revision: HEAD
+        files:
+          - path: "catalog/*.yaml"
+      selector:
+        matchExpressions:
+          - key: enabled
+            operator: In
+            values:
+              - "true"
+  template:
+    metadata:
+      name: "{{name}}"
+      namespace: argocd
+      labels:
+        tier: "{{tier}}"
+      finalizers:
+        - resources-finalizer.argocd.argoproj.io
+    spec:
+      project: default
+      sources:
+        - repoURL: "{{repoURL}}"
+          chart: "{{chart}}"
+          targetRevision: "{{targetRevision}}"
+          helm:
+            releaseName: "{{name}}"
+            valueFiles:
+              - $values/catalog/values/{{name}}.yaml
+        - repoURL: /local-gitops
+          targetRevision: HEAD
+          ref: values
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: "{{namespace}}"
+      ignoreDifferences:
+        - group: apps
+          kind: StatefulSet
+          jqPathExpressions:
+            - .spec.volumeClaimTemplates[]?.apiVersion
+            - .spec.volumeClaimTemplates[]?.kind
+        - group: postgresql.cnpg.io
+          kind: Cluster
+          jqPathExpressions:
+            - .spec.imageName
+      syncPolicy:
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+          - RespectIgnoreDifferences=true
+          - SkipDryRunOnMissingResource=true
+        retry:
+          limit: 3
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m
+```
+
+Key changes from original:
+- `syncPolicy.applicationsSync: sync` → `strategy.type: RollingSync` with 3 ordered steps
+- Added `tier: "{{tier}}"` label to template metadata
+- Removed `syncPolicy.automated` (RollingSync takes over sync triggering)
+- Added `SkipDryRunOnMissingResource=true` to syncOptions
+- Added `retry` policy for resilience
+
+- [ ] **Step 2: Commit (in sikifanso-homelab-bootstrap repo)**
+
+```bash
+cd /Users/alicanalbayrak/dev/sikifanso/sikifanso-homelab-bootstrap
+git add bootstrap/root-catalog.yaml
+git commit -m "argocd: replace parallel sync with RollingSync tier ordering"
+```
+
+---
+
+### Task 10: Add tier and dependsOn Fields to All 19 Catalog YAMLs
+
+**Files:**
+- Modify: `../sikifanso-homelab-bootstrap/catalog/*.yaml` (19 files)
+
+The catalog YAML files are read by ArgoCD's git generator using `sigs.k8s.io/yaml` unmarshal into `Entry`. Fields are placed after `enabled` to maintain the existing field order.
+
+**Tier assignments per spec:**
+- `0-operators`: cnpg-operator, prometheus-stack, external-secrets
+- `1-data`: postgresql
+- `2-services`: langfuse, temporal
+- No tier: all others (13 apps)
+
+**Dependency declarations per spec:**
+- postgresql: `[cnpg-operator, prometheus-stack]`
+- langfuse: `[cnpg-operator, postgresql]`
+- temporal: `[cnpg-operator, postgresql]`
+- All others: none
+
+- [ ] **Step 1: Update tier-0 operator entries (3 files)**
+
+**cnpg-operator.yaml** — append after `enabled: false`:
+```yaml
+tier: 0-operators
+```
+
+**prometheus-stack.yaml** — append after `enabled: false`:
+```yaml
+tier: 0-operators
+```
+
+**external-secrets.yaml** — append after `enabled: false`:
+```yaml
+tier: 0-operators
+```
+
+- [ ] **Step 2: Update tier-1 data entry (1 file)**
+
+**postgresql.yaml** — append after `enabled: false`:
+```yaml
+tier: 1-data
+dependsOn:
+  - cnpg-operator
+  - prometheus-stack
+```
+
+- [ ] **Step 3: Update tier-2 service entries (2 files)**
+
+**langfuse.yaml** — append after `enabled: false`:
+```yaml
+tier: 2-services
+dependsOn:
+  - cnpg-operator
+  - postgresql
+```
+
+**temporal.yaml** — append after `enabled: false`:
+```yaml
+tier: 2-services
+dependsOn:
+  - cnpg-operator
+  - postgresql
+```
+
+- [ ] **Step 4: Verify remaining 13 files need no changes**
+
+The following 13 entries have no `tier` and no `dependsOn` — they are unchanged: alloy, guardrails-ai, litellm-proxy, loki, nemo-guardrails, ollama, opa, presidio, qdrant, tempo, text-embeddings-inference, unstructured, valkey.
+
+ArgoCD's RollingSync syncs unmatched apps (no `tier` label) after all defined steps complete — which is the desired behavior.
+
+- [ ] **Step 5: Verify YAML is valid**
+
+Run from the bootstrap repo:
+```bash
+cd /Users/alicanalbayrak/dev/sikifanso/sikifanso-homelab-bootstrap
+for f in catalog/*.yaml; do python3 -c "import yaml; yaml.safe_load(open('$f'))" && echo "OK: $f"; done
+```
+Expected: All 19 files print OK
+
+- [ ] **Step 6: Commit (in sikifanso-homelab-bootstrap repo)**
+
+```bash
+cd /Users/alicanalbayrak/dev/sikifanso/sikifanso-homelab-bootstrap
+git add catalog/cnpg-operator.yaml catalog/prometheus-stack.yaml catalog/external-secrets.yaml \
+        catalog/postgresql.yaml catalog/langfuse.yaml catalog/temporal.yaml
+git commit -m "catalog: add tier and dependsOn fields for RollingSync ordering"
+```
+
+---
+
+### Task 11: Final Verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+cd /Users/alicanalbayrak/dev/sikifanso/sikifanso
+make test
+```
+Expected: All tests pass
+
+- [ ] **Step 2: Run linter**
+
+```bash
+cd /Users/alicanalbayrak/dev/sikifanso/sikifanso
+make lint
+```
+Expected: No lint issues
+
+- [ ] **Step 3: Verify depgraph tests specifically**
+
+```bash
+cd /Users/alicanalbayrak/dev/sikifanso/sikifanso
+go test ./internal/catalog/ -run "TestResolveDeps|TestDependents" -race -v
+```
+Expected: All 9 dependency graph tests pass
+
+- [ ] **Step 4: Build the binary**
+
+```bash
+cd /Users/alicanalbayrak/dev/sikifanso/sikifanso
+make build
+```
+Expected: `sikifanso` binary builds successfully

--- a/docs/superpowers/specs/2026-04-04-rolling-sync-design.md
+++ b/docs/superpowers/specs/2026-04-04-rolling-sync-design.md
@@ -1,0 +1,191 @@
+# Catalog App Sync Ordering via ArgoCD RollingSync + Dependency Graph
+
+**Date:** 2026-04-04
+**Status:** Approved
+
+## Problem
+
+When a profile enables multiple catalog apps (e.g. cnpg-operator + postgresql), ArgoCD syncs them all in parallel. If app B depends on CRDs from app A, app B fails because A hasn't installed its CRDs yet.
+
+Concrete failures:
+1. `postgresql` syncs before `cnpg-operator` finishes — `Cluster` CRD not found (`postgresql.cnpg.io/Cluster`)
+2. CNPG cluster chart with `monitoring.enabled: true` produces `PrometheusRule`/`PodMonitor` resources requiring `monitoring.coreos.com` CRDs from `prometheus-stack`
+
+Root cause: `root-catalog.yaml` ApplicationSet uses `syncPolicy.applicationsSync: sync` which syncs all generated Applications in parallel with no ordering.
+
+## Solution
+
+Two complementary mechanisms:
+
+1. **Server-side:** ArgoCD ApplicationSet RollingSync strategy groups apps into ordered tiers
+2. **CLI-side:** Dependency graph enables auto-enable on `app enable` and blocks unsafe `app disable`
+
+## Tier-Based RollingSync (ArgoCD Side)
+
+### How RollingSync Works
+
+- The ApplicationSet controller takes over sync triggering (replaces `syncPolicy.automated` on individual apps)
+- Apps are grouped by label (e.g. `tier: "0-operators"`)
+- Steps are processed sequentially — each step waits for all its apps to be Healthy before proceeding
+- Drift detection still works: if an app goes OutOfSync and its tier's prerequisites are healthy, the controller re-syncs it automatically
+- Must be explicitly enabled on the ArgoCD server with `--enable-progressive-syncs` flag
+- `syncPolicy.automated` (including `selfHeal`) is forcibly disabled by the controller — the controller handles all sync triggering
+- Apps not matching any step are synced last (after all defined steps complete)
+- `retry` settings in `syncPolicy` are still respected when syncs are triggered
+
+### Tier Assignments
+
+| Tier | Label | Apps |
+|------|-------|------|
+| 0 | `0-operators` | cnpg-operator, prometheus-stack, external-secrets |
+| 1 | `1-data` | postgresql |
+| 2 | `2-services` | langfuse, temporal |
+| _(none)_ | _(unmatched)_ | All independent apps — synced after all defined steps (ArgoCD native) |
+
+Tier naming convention sorts lexicographically: `0-operators` < `1-data` < `2-services`.
+
+Independent apps (litellm-proxy, ollama, qdrant, text-embeddings-inference, unstructured, guardrails-ai, nemo-guardrails, presidio, valkey, loki, tempo, alloy, opa) have no `tier` field. ArgoCD's RollingSync syncs unmatched apps after all defined steps complete.
+
+### root-catalog.yaml Changes
+
+- Replace `applicationsSync: sync` with `strategy.type: RollingSync` and step definitions matching each tier label
+- Add `tier: "{{tier}}"` label to the template metadata
+- Remove `syncPolicy.automated` (RollingSync takes over sync triggering)
+- Add `SkipDryRunOnMissingResource=true` to syncOptions
+- Add retry policy for resilience
+- Keep existing syncOptions: `CreateNamespace=true`, `ServerSideApply=true`, `RespectIgnoreDifferences=true`
+
+### ArgoCD Config
+
+Add `--enable-progressive-syncs` to the ApplicationSet controller args in `internal/infraconfig/defaults/argocd-values.yaml`.
+
+## Catalog Entry Schema Changes
+
+File: `internal/catalog/catalog.go`
+
+Add two fields to `Entry` (both `omitempty` for backward compatibility):
+
+```go
+Tier      string   `json:"tier,omitempty"`
+DependsOn []string `json:"dependsOn,omitempty"`
+```
+
+Entries without `tier` default to ArgoCD's unmatched behavior (synced last). Entries without `dependsOn` have no CLI-level dependency constraints.
+
+### Dependency Declarations
+
+| App | dependsOn |
+|-----|-----------|
+| postgresql | cnpg-operator, prometheus-stack |
+| langfuse | cnpg-operator, postgresql |
+| temporal | cnpg-operator, postgresql |
+| All others | _(none)_ |
+
+## Dependency Graph
+
+New file: `internal/catalog/depgraph.go`
+
+Three functions:
+
+- **`ResolveDeps(requested []string, all []Entry) (resolved, autoAdded []string, err error)`** — BFS transitive resolution. Returns full ordered set + which ones were auto-added. Includes cycle detection.
+- **`Dependents(name string, all []Entry) []string`** — Reverse lookup: which enabled apps depend on this app?
+- **Cycle detection** — Returns error if the dependency graph contains cycles.
+
+New file: `internal/catalog/depgraph_test.go` — Tests for DAG resolution, cycle detection, transitive deps, and reverse lookup.
+
+## ToggleWithDeps
+
+File: `internal/catalog/service.go`
+
+New function alongside existing `Toggle`:
+
+### Enable Path
+1. Load all catalog entries
+2. Call `ResolveDeps` with the requested app
+3. Auto-enable any missing dependencies
+4. Commit all changes (deps + requested app)
+5. Return `ToggleWithDepsResult` including auto-added dep names
+
+### Disable Path
+1. Load all catalog entries
+2. Call `Dependents` to find enabled apps that depend on this one
+3. If any exist and `--force` is not set: return error with message listing dependents and hint to use `--force`
+4. If `--force` or no dependents: proceed with normal disable
+
+Existing `Toggle` and `Flip` remain unchanged (used by TUI browser).
+
+### Disable --force Behavior
+
+`--force` bypasses the dependent check and disables only the requested app. It does NOT cascade-disable dependents. Users must explicitly disable leaf-to-root if they want to tear down a chain.
+
+## CLI Updates
+
+File: `cmd/sikifanso/app_cmd.go`
+
+- `appToggleAction` (~line 331): Use `ToggleWithDeps`, print auto-enabled deps notification ("auto-enabled: cnpg-operator, prometheus-stack")
+- Add `--force` flag to `appDisableCmd`
+- TUI browser flow: Unchanged (uses `Toggle`/`Flip` directly, no dep resolution)
+
+## Profile Apply Update
+
+File: `internal/profile/profile.go`
+
+- Signature changes: `Apply(...) ([]string, error)` — returns list of auto-added dep names
+- Internally calls `ResolveDeps` to expand profile apps with transitive deps before enabling
+- Returns auto-added deps so callers can notify users
+
+### Call Site Updates
+
+- `cmd/sikifanso/cluster_create.go` (~line 95): Handle `(autoAdded, err)` return, log auto-added deps
+- `internal/mcp/helpers.go` (~line 76): Handle `(autoAdded, err)` return, include in result text
+
+## MCP Handler Update
+
+File: `internal/mcp/catalog.go`
+
+- `catalogToggle` (~line 102): Use `ToggleWithDeps` instead of `Toggle`
+- Response text includes auto-added deps when enabling
+- Disable with dependents returns error (no `--force` equivalent in MCP — agents should disable explicitly)
+
+## What Doesn't Change
+
+- `internal/argocd/grpcsync/orchestrator.go` — No wave logic needed; ArgoCD handles ordering server-side via RollingSync
+- `syncAfterMutation` middleware — Continues working as-is
+- `Toggle` / `Flip` — Preserved for TUI browser
+
+## Catalog YAML Updates
+
+All 19 entries in `sikifanso-homelab-bootstrap/catalog/*.yaml` get `tier` and `dependsOn` fields where applicable:
+
+**Tier 0-operators:** cnpg-operator, prometheus-stack, external-secrets
+**Tier 1-data:** postgresql
+**Tier 2-services:** langfuse, temporal
+**No tier (unmatched):** alloy, guardrails-ai, litellm-proxy, loki, nemo-guardrails, ollama, opa, presidio, qdrant, tempo, text-embeddings-inference, unstructured, valkey
+
+## Verification
+
+1. `make test` — all existing tests pass
+2. `go test ./internal/catalog/ -run TestResolveDeps -race` — dependency resolution
+3. `make lint` — no lint issues
+4. End-to-end: `sikifanso cluster create --profile agent-minimal` — verify postgresql waits for cnpg-operator
+5. `sikifanso app enable postgresql` — verify cnpg-operator + prometheus-stack auto-enabled
+6. `sikifanso app disable cnpg-operator` — verify error listing postgresql as dependent
+7. `sikifanso app disable cnpg-operator --force` — verify it proceeds without cascade
+8. Verify ArgoCD ApplicationSet status shows step-based progress
+
+## Key Files
+
+| File | Change |
+|------|--------|
+| `sikifanso/internal/catalog/catalog.go` | Add `Tier` and `DependsOn` fields to `Entry` |
+| `sikifanso/internal/catalog/depgraph.go` | NEW — `ResolveDeps`, `Dependents`, cycle detection |
+| `sikifanso/internal/catalog/depgraph_test.go` | NEW — DAG resolution tests |
+| `sikifanso/internal/catalog/service.go` | Add `ToggleWithDeps` |
+| `sikifanso/cmd/sikifanso/app_cmd.go` | Use `ToggleWithDeps`, `--force` flag, notify auto-deps |
+| `sikifanso/internal/profile/profile.go` | Resolve transitive deps in `Apply`, return `([]string, error)` |
+| `sikifanso/cmd/sikifanso/cluster_create.go` | Handle updated `Apply` return |
+| `sikifanso/internal/mcp/helpers.go` | Handle updated `Apply` return |
+| `sikifanso/internal/mcp/catalog.go` | Use `ToggleWithDeps` |
+| `sikifanso/internal/infraconfig/defaults/argocd-values.yaml` | Enable `--enable-progressive-syncs` |
+| `sikifanso-homelab-bootstrap/bootstrap/root-catalog.yaml` | Add RollingSync strategy + tier label |
+| `sikifanso-homelab-bootstrap/catalog/*.yaml` | Add `tier` and `dependsOn` fields to all 19 entries |

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -14,14 +14,16 @@ import (
 
 // Entry represents a single application in the catalog.
 type Entry struct {
-	Name           string `json:"name"`
-	Category       string `json:"category"`
-	Description    string `json:"description"`
-	RepoURL        string `json:"repoURL"`
-	Chart          string `json:"chart"`
-	TargetRevision string `json:"targetRevision"`
-	Namespace      string `json:"namespace"`
-	Enabled        bool   `json:"enabled"`
+	Name           string   `json:"name"`
+	Category       string   `json:"category"`
+	Description    string   `json:"description"`
+	RepoURL        string   `json:"repoURL"`
+	Chart          string   `json:"chart"`
+	TargetRevision string   `json:"targetRevision"`
+	Namespace      string   `json:"namespace"`
+	Enabled        bool     `json:"enabled"`
+	Tier           string   `json:"tier,omitempty"`
+	DependsOn      []string `json:"dependsOn,omitempty"`
 }
 
 // CatalogDir returns the path to the catalog directory within gitOpsPath.

--- a/internal/catalog/depgraph.go
+++ b/internal/catalog/depgraph.go
@@ -1,0 +1,94 @@
+package catalog
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ResolveDeps performs BFS transitive dependency resolution. Given a set of
+// requested app names and all catalog entries, it returns:
+//   - resolved: the full ordered set (deps before dependents)
+//   - autoAdded: names that were not in the original requested set
+//
+// Returns an error if a cycle is detected or a dependency does not exist.
+func ResolveDeps(requested []string, all []Entry) (resolved, autoAdded []string, err error) {
+	byName := make(map[string]Entry, len(all))
+	for _, e := range all {
+		byName[e.Name] = e
+	}
+
+	requestedSet := make(map[string]bool, len(requested))
+	for _, name := range requested {
+		requestedSet[name] = true
+	}
+
+	// DFS with cycle detection via "visiting" state.
+	const (
+		unvisited = 0
+		visiting  = 1
+		visited   = 2
+	)
+	state := make(map[string]int)
+	var order []string
+
+	var visit func(name string, path []string) error
+	visit = func(name string, path []string) error {
+		switch state[name] {
+		case visited:
+			return nil
+		case visiting:
+			return fmt.Errorf("dependency cycle detected: %s -> %s", strings.Join(path, " -> "), name)
+		}
+
+		entry, ok := byName[name]
+		if !ok {
+			return fmt.Errorf("dependency %q not found in catalog", name)
+		}
+
+		state[name] = visiting
+		for _, dep := range entry.DependsOn {
+			if err := visit(dep, append(path, name)); err != nil {
+				return err
+			}
+		}
+		state[name] = visited
+		order = append(order, name)
+		return nil
+	}
+
+	for _, name := range requested {
+		if err := visit(name, nil); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	// Determine which were auto-added (in order but not originally requested).
+	var added []string
+	for _, name := range order {
+		if !requestedSet[name] {
+			added = append(added, name)
+		}
+	}
+
+	return order, added, nil
+}
+
+// Dependents returns the names of enabled entries that directly depend on the
+// given app name. The result is sorted for deterministic output.
+func Dependents(name string, all []Entry) []string {
+	var deps []string
+	for _, e := range all {
+		if !e.Enabled {
+			continue
+		}
+		for _, d := range e.DependsOn {
+			if d == name {
+				deps = append(deps, e.Name)
+				break
+			}
+		}
+	}
+	sort.Strings(deps)
+	return deps
+}

--- a/internal/catalog/depgraph.go
+++ b/internal/catalog/depgraph.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// ResolveDeps performs BFS transitive dependency resolution. Given a set of
+// ResolveDeps performs DFS transitive dependency resolution. Given a set of
 // requested app names and all catalog entries, it returns:
 //   - resolved: the full ordered set (deps before dependents)
 //   - autoAdded: names that were not in the original requested set
@@ -48,7 +48,7 @@ func ResolveDeps(requested []string, all []Entry) (resolved, autoAdded []string,
 
 		state[name] = visiting
 		for _, dep := range entry.DependsOn {
-			if err := visit(dep, append(path, name)); err != nil {
+			if err := visit(dep, append(append([]string{}, path...), name)); err != nil {
 				return err
 			}
 		}

--- a/internal/catalog/depgraph_test.go
+++ b/internal/catalog/depgraph_test.go
@@ -1,0 +1,147 @@
+package catalog
+
+import (
+	"testing"
+)
+
+func TestResolveDeps_NoDeps(t *testing.T) {
+	t.Parallel()
+	all := []Entry{
+		{Name: "ollama"},
+		{Name: "qdrant"},
+	}
+	resolved, autoAdded, err := ResolveDeps([]string{"ollama"}, all)
+	if err != nil {
+		t.Fatalf("ResolveDeps: %v", err)
+	}
+	if len(resolved) != 1 || resolved[0] != "ollama" {
+		t.Errorf("resolved = %v, want [ollama]", resolved)
+	}
+	if len(autoAdded) != 0 {
+		t.Errorf("autoAdded = %v, want empty", autoAdded)
+	}
+}
+
+func TestResolveDeps_DirectDeps(t *testing.T) {
+	t.Parallel()
+	all := []Entry{
+		{Name: "cnpg-operator"},
+		{Name: "prometheus-stack"},
+		{Name: "postgresql", DependsOn: []string{"cnpg-operator", "prometheus-stack"}},
+	}
+	resolved, autoAdded, err := ResolveDeps([]string{"postgresql"}, all)
+	if err != nil {
+		t.Fatalf("ResolveDeps: %v", err)
+	}
+	if len(resolved) != 3 {
+		t.Fatalf("resolved = %v, want 3 entries", resolved)
+	}
+	if resolved[len(resolved)-1] != "postgresql" {
+		t.Errorf("last resolved = %q, want postgresql", resolved[len(resolved)-1])
+	}
+	if len(autoAdded) != 2 {
+		t.Errorf("autoAdded = %v, want 2 entries", autoAdded)
+	}
+}
+
+func TestResolveDeps_TransitiveDeps(t *testing.T) {
+	t.Parallel()
+	all := []Entry{
+		{Name: "cnpg-operator"},
+		{Name: "prometheus-stack"},
+		{Name: "postgresql", DependsOn: []string{"cnpg-operator", "prometheus-stack"}},
+		{Name: "langfuse", DependsOn: []string{"cnpg-operator", "postgresql"}},
+	}
+	resolved, autoAdded, err := ResolveDeps([]string{"langfuse"}, all)
+	if err != nil {
+		t.Fatalf("ResolveDeps: %v", err)
+	}
+	if len(resolved) != 4 {
+		t.Fatalf("resolved = %v, want 4 entries", resolved)
+	}
+	if resolved[len(resolved)-1] != "langfuse" {
+		t.Errorf("last resolved = %q, want langfuse", resolved[len(resolved)-1])
+	}
+	if len(autoAdded) != 3 {
+		t.Errorf("autoAdded = %v, want 3 entries", autoAdded)
+	}
+}
+
+func TestResolveDeps_AlreadyRequested(t *testing.T) {
+	t.Parallel()
+	all := []Entry{
+		{Name: "cnpg-operator"},
+		{Name: "postgresql", DependsOn: []string{"cnpg-operator"}},
+	}
+	resolved, autoAdded, err := ResolveDeps([]string{"cnpg-operator", "postgresql"}, all)
+	if err != nil {
+		t.Fatalf("ResolveDeps: %v", err)
+	}
+	if len(resolved) != 2 {
+		t.Fatalf("resolved = %v, want 2 entries", resolved)
+	}
+	if len(autoAdded) != 0 {
+		t.Errorf("autoAdded = %v, want empty (both were requested)", autoAdded)
+	}
+}
+
+func TestResolveDeps_CycleDetection(t *testing.T) {
+	t.Parallel()
+	all := []Entry{
+		{Name: "a", DependsOn: []string{"b"}},
+		{Name: "b", DependsOn: []string{"a"}},
+	}
+	_, _, err := ResolveDeps([]string{"a"}, all)
+	if err == nil {
+		t.Fatal("expected cycle error, got nil")
+	}
+}
+
+func TestResolveDeps_UnknownDep(t *testing.T) {
+	t.Parallel()
+	all := []Entry{
+		{Name: "postgresql", DependsOn: []string{"nonexistent"}},
+	}
+	_, _, err := ResolveDeps([]string{"postgresql"}, all)
+	if err == nil {
+		t.Fatal("expected error for unknown dep, got nil")
+	}
+}
+
+func TestDependents_Direct(t *testing.T) {
+	t.Parallel()
+	all := []Entry{
+		{Name: "cnpg-operator", Enabled: true},
+		{Name: "postgresql", Enabled: true, DependsOn: []string{"cnpg-operator", "prometheus-stack"}},
+		{Name: "langfuse", Enabled: true, DependsOn: []string{"cnpg-operator", "postgresql"}},
+		{Name: "ollama", Enabled: true},
+	}
+	deps := Dependents("cnpg-operator", all)
+	if len(deps) != 2 {
+		t.Fatalf("Dependents = %v, want 2 entries (postgresql, langfuse)", deps)
+	}
+}
+
+func TestDependents_OnlyEnabled(t *testing.T) {
+	t.Parallel()
+	all := []Entry{
+		{Name: "cnpg-operator", Enabled: true},
+		{Name: "postgresql", Enabled: false, DependsOn: []string{"cnpg-operator"}},
+	}
+	deps := Dependents("cnpg-operator", all)
+	if len(deps) != 0 {
+		t.Errorf("Dependents = %v, want empty (postgresql is disabled)", deps)
+	}
+}
+
+func TestDependents_NoDependents(t *testing.T) {
+	t.Parallel()
+	all := []Entry{
+		{Name: "ollama", Enabled: true},
+		{Name: "qdrant", Enabled: true},
+	}
+	deps := Dependents("ollama", all)
+	if len(deps) != 0 {
+		t.Errorf("Dependents = %v, want empty", deps)
+	}
+}

--- a/internal/catalog/service.go
+++ b/internal/catalog/service.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/alicanalbayrak/sikifanso/internal/gitops"
 )
@@ -56,4 +57,109 @@ func Flip(gitOpsPath, name string) (*ToggleResult, error) {
 		return nil, err
 	}
 	return Toggle(gitOpsPath, name, !entry.Enabled)
+}
+
+// ToggleWithDepsResult describes the outcome of a ToggleWithDeps operation.
+type ToggleWithDepsResult struct {
+	Name      string
+	Enabled   bool
+	NoChange  bool
+	AutoDeps  []string // dep names that were auto-enabled (enable path only)
+}
+
+// ToggleWithDeps is like Toggle but resolves transitive dependencies.
+//
+// Enable path: auto-enables missing dependencies, commits all changes together.
+// Disable path: returns error listing dependents unless force is true.
+// Force bypasses the dependent check but does NOT cascade-disable dependents.
+func ToggleWithDeps(gitOpsPath, name string, enable, force bool) (*ToggleWithDepsResult, error) {
+	entry, err := Find(gitOpsPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if entry.Enabled == enable {
+		return &ToggleWithDepsResult{Name: name, Enabled: enable, NoChange: true}, nil
+	}
+
+	if enable {
+		return toggleWithDepsEnable(gitOpsPath, name)
+	}
+	return toggleWithDepsDisable(gitOpsPath, name, force)
+}
+
+func toggleWithDepsEnable(gitOpsPath, name string) (*ToggleWithDepsResult, error) {
+	all, err := List(gitOpsPath)
+	if err != nil {
+		return nil, fmt.Errorf("listing catalog: %w", err)
+	}
+
+	resolved, _, err := ResolveDeps([]string{name}, all)
+	if err != nil {
+		return nil, fmt.Errorf("resolving dependencies: %w", err)
+	}
+
+	// Build a map of currently enabled entries to skip no-ops.
+	enabledSet := make(map[string]bool, len(all))
+	for _, e := range all {
+		if e.Enabled {
+			enabledSet[e.Name] = true
+		}
+	}
+
+	var commitPaths []string
+	var actualAutoAdded []string
+	for _, app := range resolved {
+		if enabledSet[app] {
+			continue // already enabled
+		}
+		if err := SetEnabled(gitOpsPath, app, true); err != nil {
+			return nil, fmt.Errorf("enabling %s: %w", app, err)
+		}
+		commitPaths = append(commitPaths, fmt.Sprintf("catalog/%s.yaml", app))
+		if app != name {
+			actualAutoAdded = append(actualAutoAdded, app)
+		}
+	}
+
+	if len(commitPaths) > 0 {
+		commitMsg := fmt.Sprintf("catalog: enable %s", name)
+		if len(actualAutoAdded) > 0 {
+			commitMsg += fmt.Sprintf(" (auto-deps: %s)", strings.Join(actualAutoAdded, ", "))
+		}
+		if err := gitops.Commit(gitOpsPath, commitMsg, commitPaths...); err != nil {
+			return nil, fmt.Errorf("committing changes: %w", err)
+		}
+	}
+
+	return &ToggleWithDepsResult{
+		Name:     name,
+		Enabled:  true,
+		AutoDeps: actualAutoAdded,
+	}, nil
+}
+
+func toggleWithDepsDisable(gitOpsPath, name string, force bool) (*ToggleWithDepsResult, error) {
+	if !force {
+		all, err := List(gitOpsPath)
+		if err != nil {
+			return nil, fmt.Errorf("listing catalog: %w", err)
+		}
+		deps := Dependents(name, all)
+		if len(deps) > 0 {
+			return nil, fmt.Errorf("cannot disable %s: required by %s (use --force to override)", name, strings.Join(deps, ", "))
+		}
+	}
+
+	if err := SetEnabled(gitOpsPath, name, false); err != nil {
+		return nil, fmt.Errorf("disabling %s: %w", name, err)
+	}
+
+	commitMsg := fmt.Sprintf("catalog: disable %s", name)
+	commitPath := fmt.Sprintf("catalog/%s.yaml", name)
+	if err := gitops.Commit(gitOpsPath, commitMsg, commitPath); err != nil {
+		return nil, fmt.Errorf("committing change: %w", err)
+	}
+
+	return &ToggleWithDepsResult{Name: name, Enabled: false}, nil
 }

--- a/internal/catalog/service.go
+++ b/internal/catalog/service.go
@@ -61,10 +61,10 @@ func Flip(gitOpsPath, name string) (*ToggleResult, error) {
 
 // ToggleWithDepsResult describes the outcome of a ToggleWithDeps operation.
 type ToggleWithDepsResult struct {
-	Name      string
-	Enabled   bool
-	NoChange  bool
-	AutoDeps  []string // dep names that were auto-enabled (enable path only)
+	Name     string
+	Enabled  bool
+	NoChange bool
+	AutoDeps []string // dep names that were auto-enabled (enable path only)
 }
 
 // ToggleWithDeps is like Toggle but resolves transitive dependencies.

--- a/internal/catalog/service.go
+++ b/internal/catalog/service.go
@@ -78,8 +78,8 @@ func ToggleWithDeps(gitOpsPath, name string, enable, force bool) (*ToggleWithDep
 		return nil, err
 	}
 
-	if entry.Enabled == enable {
-		return &ToggleWithDepsResult{Name: name, Enabled: enable, NoChange: true}, nil
+	if !enable && !entry.Enabled {
+		return &ToggleWithDepsResult{Name: name, Enabled: false, NoChange: true}, nil
 	}
 
 	if enable {
@@ -122,14 +122,16 @@ func toggleWithDepsEnable(gitOpsPath, name string) (*ToggleWithDepsResult, error
 		}
 	}
 
-	if len(commitPaths) > 0 {
-		commitMsg := fmt.Sprintf("catalog: enable %s", name)
-		if len(actualAutoAdded) > 0 {
-			commitMsg += fmt.Sprintf(" (auto-deps: %s)", strings.Join(actualAutoAdded, ", "))
-		}
-		if err := gitops.Commit(gitOpsPath, commitMsg, commitPaths...); err != nil {
-			return nil, fmt.Errorf("committing changes: %w", err)
-		}
+	if len(commitPaths) == 0 {
+		return &ToggleWithDepsResult{Name: name, Enabled: true, NoChange: true}, nil
+	}
+
+	commitMsg := fmt.Sprintf("catalog: enable %s", name)
+	if len(actualAutoAdded) > 0 {
+		commitMsg += fmt.Sprintf(" (auto-deps: %s)", strings.Join(actualAutoAdded, ", "))
+	}
+	if err := gitops.Commit(gitOpsPath, commitMsg, commitPaths...); err != nil {
+		return nil, fmt.Errorf("committing changes: %w", err)
 	}
 
 	return &ToggleWithDepsResult{

--- a/internal/infraconfig/defaults/argocd-values.yaml
+++ b/internal/infraconfig/defaults/argocd-values.yaml
@@ -75,6 +75,7 @@ applicationSet:
   enabled: true
   extraArgs:
     - "--repo-server-plaintext"
+    - "--enable-progressive-syncs"
   resources:
     requests:
       cpu: 25m

--- a/internal/mcp/catalog.go
+++ b/internal/mcp/catalog.go
@@ -110,7 +110,8 @@ func catalogToggle(ctx context.Context, deps *Deps, clusterName, appName string,
 		return r, sv, e
 	}
 
-	result, err := catalog.Toggle(sess.GitOpsPath, appName, enable)
+	// MCP has no --force equivalent — agents must disable dependents explicitly.
+	result, err := catalog.ToggleWithDeps(sess.GitOpsPath, appName, enable, false)
 	if err != nil {
 		return errResult(err)
 	}
@@ -119,5 +120,8 @@ func catalogToggle(ctx context.Context, deps *Deps, clusterName, appName string,
 	}
 
 	msg := fmt.Sprintf("%s %s and committed to gitops repo.", appName, past)
+	if len(result.AutoDeps) > 0 {
+		msg += fmt.Sprintf(" Auto-enabled dependencies: %s.", strings.Join(result.AutoDeps, ", "))
+	}
 	return textResult(appendSyncStatus(ctx, deps, sess, msg, "catalog"))
 }

--- a/internal/mcp/helpers.go
+++ b/internal/mcp/helpers.go
@@ -81,7 +81,7 @@ func applyProfileToCluster(ctx context.Context, deps *Deps, sess *session.Sessio
 		return "", fmt.Errorf("applying profile %q: %w", profileName, err)
 	}
 
-	result := fmt.Sprintf("Profile %q applied (%d apps enabled).", profileName, len(apps))
+	result := fmt.Sprintf("Profile %q applied (%d apps enabled).", profileName, len(apps)+len(autoAdded))
 	if len(autoAdded) > 0 {
 		result += fmt.Sprintf("\n  Auto-enabled dependencies: %s", strings.Join(autoAdded, ", "))
 	}

--- a/internal/mcp/helpers.go
+++ b/internal/mcp/helpers.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/alicanalbayrak/sikifanso/internal/argocd/appsetreconcile"
 	"github.com/alicanalbayrak/sikifanso/internal/kube"
@@ -73,13 +74,17 @@ func applyProfileToCluster(ctx context.Context, deps *Deps, sess *session.Sessio
 	}
 
 	var warnings []string
-	if err := profile.Apply(sess.GitOpsPath, profileName, apps, func(msg string) {
+	autoAdded, err := profile.Apply(sess.GitOpsPath, profileName, apps, func(msg string) {
 		warnings = append(warnings, msg)
-	}); err != nil {
+	})
+	if err != nil {
 		return "", fmt.Errorf("applying profile %q: %w", profileName, err)
 	}
 
 	result := fmt.Sprintf("Profile %q applied (%d apps enabled).", profileName, len(apps))
+	if len(autoAdded) > 0 {
+		result += fmt.Sprintf("\n  Auto-enabled dependencies: %s", strings.Join(autoAdded, ", "))
+	}
 	for _, w := range warnings {
 		result += fmt.Sprintf("\n  Warning: %s", w)
 	}

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -135,8 +135,18 @@ func Apply(gitOpsPath string, profileName string, apps []string, warn func(strin
 		return nil, fmt.Errorf("resolving dependencies: %w", err)
 	}
 
+	enabledSet := make(map[string]bool, len(all))
+	for _, e := range all {
+		if e.Enabled {
+			enabledSet[e.Name] = true
+		}
+	}
+
 	var committed []string
 	for _, app := range resolved {
+		if enabledSet[app] {
+			continue // already enabled — no-op
+		}
 		if err := catalog.SetEnabled(gitOpsPath, app, true); err != nil {
 			if warn != nil {
 				warn(fmt.Sprintf("skipping %s: %s", app, err))

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -102,16 +102,24 @@ func Resolve(profileStr string) ([]string, error) {
 }
 
 // Apply enables the given apps in the catalog at gitOpsPath and commits the
-// changes in a single commit. Apps that don't exist in the catalog are skipped
-// with a warning via the provided warn function. The profileName is used in the
-// commit message for traceability.
+// changes in a single commit. Transitive dependencies are resolved and
+// auto-enabled. Returns the names of auto-added dependencies.
 //
-// Each SetEnabled call writes to disk independently. On partial failure,
-// successfully written files are committed; skipped apps are warned.
-// If Commit itself fails, the gitops worktree may be left dirty.
-func Apply(gitOpsPath string, profileName string, apps []string, warn func(string)) error {
+// Apps that don't exist in the catalog are skipped with a warning via the
+// provided warn function. The profileName is used in the commit message.
+func Apply(gitOpsPath string, profileName string, apps []string, warn func(string)) ([]string, error) {
+	all, err := catalog.List(gitOpsPath)
+	if err != nil {
+		return nil, fmt.Errorf("listing catalog: %w", err)
+	}
+
+	resolved, autoAdded, err := catalog.ResolveDeps(apps, all)
+	if err != nil {
+		return nil, fmt.Errorf("resolving dependencies: %w", err)
+	}
+
 	var committed []string
-	for _, app := range apps {
+	for _, app := range resolved {
 		if err := catalog.SetEnabled(gitOpsPath, app, true); err != nil {
 			if warn != nil {
 				warn(fmt.Sprintf("skipping %s: %s", app, err))
@@ -122,11 +130,14 @@ func Apply(gitOpsPath string, profileName string, apps []string, warn func(strin
 	}
 
 	if len(committed) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	msg := fmt.Sprintf("profile: enable %s apps", profileName)
-	return gitops.Commit(gitOpsPath, msg, committed...)
+	if err := gitops.Commit(gitOpsPath, msg, committed...); err != nil {
+		return nil, err
+	}
+	return autoAdded, nil
 }
 
 // Names returns the sorted list of available profile names (for shell completion).

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -130,9 +130,14 @@ func Apply(gitOpsPath string, profileName string, apps []string, warn func(strin
 		return nil, nil
 	}
 
-	resolved, autoAdded, err := catalog.ResolveDeps(known, all)
+	resolved, _, err := catalog.ResolveDeps(known, all)
 	if err != nil {
 		return nil, fmt.Errorf("resolving dependencies: %w", err)
+	}
+
+	knownSet := make(map[string]bool, len(known))
+	for _, k := range known {
+		knownSet[k] = true
 	}
 
 	enabledSet := make(map[string]bool, len(all))
@@ -142,7 +147,8 @@ func Apply(gitOpsPath string, profileName string, apps []string, warn func(strin
 		}
 	}
 
-	var committed []string
+	var commitPaths []string
+	var autoAdded []string
 	for _, app := range resolved {
 		if enabledSet[app] {
 			continue // already enabled — no-op
@@ -153,15 +159,18 @@ func Apply(gitOpsPath string, profileName string, apps []string, warn func(strin
 			}
 			continue
 		}
-		committed = append(committed, fmt.Sprintf("catalog/%s.yaml", app))
+		commitPaths = append(commitPaths, fmt.Sprintf("catalog/%s.yaml", app))
+		if !knownSet[app] {
+			autoAdded = append(autoAdded, app)
+		}
 	}
 
-	if len(committed) == 0 {
+	if len(commitPaths) == 0 {
 		return nil, nil
 	}
 
 	msg := fmt.Sprintf("profile: enable %s apps", profileName)
-	if err := gitops.Commit(gitOpsPath, msg, committed...); err != nil {
+	if err := gitops.Commit(gitOpsPath, msg, commitPaths...); err != nil {
 		return nil, err
 	}
 	return autoAdded, nil

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -113,7 +113,24 @@ func Apply(gitOpsPath string, profileName string, apps []string, warn func(strin
 		return nil, fmt.Errorf("listing catalog: %w", err)
 	}
 
-	resolved, autoAdded, err := catalog.ResolveDeps(apps, all)
+	// Filter out apps that don't exist in the catalog — warn and skip.
+	catalogSet := make(map[string]bool, len(all))
+	for _, e := range all {
+		catalogSet[e.Name] = true
+	}
+	var known []string
+	for _, app := range apps {
+		if catalogSet[app] {
+			known = append(known, app)
+		} else if warn != nil {
+			warn(fmt.Sprintf("skipping %s: not found in catalog", app))
+		}
+	}
+	if len(known) == 0 {
+		return nil, nil
+	}
+
+	resolved, autoAdded, err := catalog.ResolveDeps(known, all)
 	if err != nil {
 		return nil, fmt.Errorf("resolving dependencies: %w", err)
 	}

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -155,7 +155,7 @@ func TestApply_EnablesAppsOnDisk(t *testing.T) {
 
 	apps := []string{"litellm-proxy", "langfuse", "postgresql"}
 	var warnings []string
-	err := Apply(dir, "agent-minimal", apps, func(msg string) {
+	_, err := Apply(dir, "agent-minimal", apps, func(msg string) {
 		warnings = append(warnings, msg)
 	})
 	if err != nil {
@@ -202,7 +202,7 @@ func TestApply_SkipsMissingApps(t *testing.T) {
 	initGitRepo(t, dir)
 
 	var warnings []string
-	err := Apply(dir, "test", []string{"nonexistent", "postgresql"}, func(msg string) {
+	_, err := Apply(dir, "test", []string{"nonexistent", "postgresql"}, func(msg string) {
 		warnings = append(warnings, msg)
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add tier-based ArgoCD ApplicationSet RollingSync strategy so CRD-providing operators sync before apps that depend on them (e.g. cnpg-operator before postgresql)
- Add CLI-side dependency graph that auto-enables transitive deps on `app enable` and blocks unsafe `app disable` unless `--force` is passed
- Update `profile.Apply` to resolve transitive dependencies before enabling, returning auto-added dep names to callers

## Changes

**Catalog schema** — `Tier` and `DependsOn` fields added to `Entry` struct (`omitempty` for backward compat)

**Dependency graph** (`internal/catalog/depgraph.go`) — DFS topological sort with cycle detection via three-state coloring. `ResolveDeps` returns ordered set + auto-added names. `Dependents` does reverse lookup on enabled entries.

**ToggleWithDeps** (`internal/catalog/service.go`) — Enable path: resolve deps, skip already-enabled, commit all together. Disable path: check dependents, error unless `--force`.

**CLI** (`cmd/sikifanso/app_cmd.go`) — `app disable` gets `--force` flag. `appToggleAction` uses `ToggleWithDeps`, prints auto-enabled deps, syncs all affected apps.

**Profile** (`internal/profile/profile.go`) — `Apply` now calls `ResolveDeps` to expand profile apps with transitive deps. Returns `([]string, error)`. Unknown apps filtered with warning before resolution.

**MCP** — `catalogToggle` uses `ToggleWithDeps` (force=false). `applyProfileToCluster` handles new `Apply` return.

**ArgoCD config** — `--enable-progressive-syncs` added to ApplicationSet controller args.

## Companion PR

sikifanso/sikifanso-homelab-bootstrap — `root-catalog.yaml` RollingSync strategy + tier/dependsOn fields on 6 catalog entries

## Test plan

- [x] `make test` — all tests pass (including 9 new depgraph tests)
- [x] `make lint` — zero issues
- [x] `make build` — binary builds clean
- [ ] E2E: `sikifanso cluster create --profile agent-minimal` — verify postgresql waits for cnpg-operator
- [ ] E2E: `sikifanso app enable postgresql` — verify cnpg-operator + prometheus-stack auto-enabled
- [ ] E2E: `sikifanso app disable cnpg-operator` — verify error listing postgresql as dependent
- [ ] E2E: `sikifanso app disable cnpg-operator --force` — verify it proceeds

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

**[Linus Torvalds Mode]** Oh look, another PR that reinvents a dependency resolver in 95 lines of Go and expects a medal. The DFS cycle detection is clean, the RollingSync tier story is coherent, and the profile.Apply rewrite correctly guards against spurious re-enables — whoever wrote the previous iteration of this deserves the side-eye they're getting. That said, this isn't a victory lap yet.

- **Catalog `Entry` schema** (`catalog.go`): `Tier` and `DependsOn` added with `omitempty` — backward-compatible, no issues
- **`ResolveDeps` / `Dependents`** (`depgraph.go`): Three-state DFS is correct; cycle error messages are readable; `Dependents` correctly filters disabled entries
- **`ToggleWithDeps` enable path** (`service.go`): Correctly proceeds to dep resolution even when the target is already enabled, fixing the silent-NoChange regression the previous review caught — but the loop writes files to disk before the git commit; if any mid-loop `SetEnabled` call fails, earlier writes are already on disk with no commit, leaving a dirty working tree that poisons the next `enabledSet` snapshot
- **`ToggleWithDeps` disable path** (`service.go`): `force` is correctly scoped to the disable path (`!enable && cmd.Bool("force")`) and `toggleWithDepsDisable` correctly checks direct dependents before blocking
- **`profile.Apply`** (`profile.go`): `enabledSet` guard prevents spurious re-writes; `autoAdded` is filtered against both `knownSet` and `enabledSet`, fixing both concerns from the previous review round
- **MCP `applyProfileToCluster`** (`helpers.go`): App count in the result message (`len(apps)+len(autoAdded)`) still overcounts when profile apps are already enabled — `autoAdded` from `Apply` only contains newly-enabled deps, not the profile apps that were written; cosmetic but will mislead AI agents
- **ArgoCD values** (`argocd-values.yaml`): `--enable-progressive-syncs` correctly placed in `applicationSet.extraArgs`
- **Service layer tests**: `ToggleWithDeps`, `toggleWithDepsEnable`, and `toggleWithDepsDisable` — the entire new mutation path — have zero unit tests; `profile_test.go`'s `TestApply_EnablesAppsOnDisk` uses no `DependsOn` entries so transitive dep resolution is never exercised

The previous-round issues (spurious commits from missing enabled guard, wrong `autoAdded` including already-enabled deps) appear fully addressed. The remaining gaps are the partial-write atomicity risk and the absent service-layer unit tests.

<h3>Confidence Score: 4/5</h3>

**[Linus Torvalds Mode]** This PR is better than average garbage — the dep graph is correct, the profile.Apply fixes are solid — but it ships mutation logic with zero unit tests and a partial-write state risk that will quietly corrupt your gitops working tree on any mid-loop disk error. Merge only after the author acknowledges these gaps.

Congratulations on writing a mostly-correct dependency resolver on the first real try — the three-state DFS, cycle detection, and the profile.Apply guards all check out. But ToggleWithDeps has no unit tests whatsoever, and toggleWithDepsEnable can leave the git working tree dirty on error because SetEnabled writes unconditionally in a loop before the commit. Those aren't hard blockers in a happy-path system, but they are embarrassing gaps for code that mutates your single source of truth. P2 findings only, but two of them are in the same critical file with zero test coverage to catch regressions — hence 4 rather than 5.

internal/catalog/service.go deserves your fullest contempt — it holds all the new mutation logic, has no tests, and will happily leave uncommitted YAML lying around on disk if anything goes sideways.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/sikifanso/app_cmd.go | Adds --force to disable cmd and wires ToggleWithDeps correctly; force is safely scoped to the disable path via !enable && |
| cmd/sikifanso/cluster_create.go | Updates profile.Apply call site to handle new ([]string, error) signature; auto-dep logging added correctly |
| internal/catalog/catalog.go | Adds Tier and DependsOn fields to Entry with omitempty for backward compatibility; no behavioral changes |
| internal/catalog/depgraph.go | New DFS topological sort with three-state cycle detection; path-slice aliasing handled correctly; clean and correct |
| internal/catalog/depgraph_test.go | 9 tests covering NoDeps, DirectDeps, TransitiveDeps, AlreadyRequested, CycleDetection, UnknownDep, and Dependents edge cases |
| internal/catalog/service.go | ToggleWithDeps has partial-write state risk on error path and zero unit tests for the new service-layer functions |
| internal/infraconfig/defaults/argocd-values.yaml | Adds --enable-progressive-syncs to applicationSet.extraArgs to enable RollingSync strategy |
| internal/mcp/catalog.go | Migrates catalogToggle to ToggleWithDeps (force=false); applyProfileToCluster handles new Apply signature correctly |
| internal/mcp/helpers.go | applyProfileToCluster app count uses len(apps)+len(autoAdded) which overcounts when profile apps are already enabled |
| internal/profile/profile.go | Apply correctly guards with enabledSet before each SetEnabled call and builds accurate autoAdded filtered by both knownSet and enabledSet |
| internal/profile/profile_test.go | TestApply_EnablesAppsOnDisk uses no DependsOn entries, leaving the transitive dep resolution path entirely untested |
| docs/superpowers/plans/2026-04-04-rolling-sync-depgraph.md | Design plan doc only; no code changes |
| docs/superpowers/specs/2026-04-04-rolling-sync-design.md | Spec doc for rolling sync design; no code changes |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor User
    participant CLI as app_cmd.go
    participant Svc as service.go
    participant DG as depgraph.go
    participant FS as Catalog YAMLs
    participant Git as gitops.Commit
    participant ArgoCD

    User->>CLI: sikifanso app enable postgresql
    CLI->>Svc: ToggleWithDeps(path, postgresql, enable=true, force=false)
    Svc->>FS: Find(postgresql)
    FS-->>Svc: entry{Enabled: false}
    Svc->>Svc: toggleWithDepsEnable(path, postgresql)
    Svc->>FS: List() — snapshot enabledSet
    Svc->>DG: ResolveDeps([postgresql], all)
    DG-->>Svc: resolved=[cnpg-operator, prometheus-stack, postgresql]\nautoAdded=[cnpg-operator, prometheus-stack]
    loop each resolved app not in enabledSet
        Svc->>FS: SetEnabled(app, true)
    end
    Svc->>Git: Commit(catalog/cnpg-operator.yaml, catalog/prometheus-stack.yaml, catalog/postgresql.yaml)
    Svc-->>CLI: ToggleWithDepsResult{AutoDeps: [cnpg-operator, prometheus-stack]}
    CLI->>ArgoCD: syncAfterMutation(catalog)
    ArgoCD-->>CLI: reconciliation triggered
    CLI->>User: auto-enabled: cnpg-operator, prometheus-stack\npostgresql enabled ✓
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/catalog/service.go
Line: 116-122

Comment:
**Partial write leaves uncommitted state on error**

This is a crash course in data corruption, congratulations. Nothing says 'I understand git' like leaving uncommitted garbage on disk when things go wrong.

`SetEnabled` writes each YAML to disk immediately inside the loop with no rollback. If `cnpg-operator.yaml` is written successfully but a later call in the same loop fails, the function returns an error with those earlier files already modified on disk. On the next call, `List()` reads the dirty files, `cnpg-operator` appears in `enabledSet` as enabled, the enable path skips it, and it never lands in a git commit — the dep is in an inconsistently-applied state with no history.

Consider staging all the file paths and content in memory first, writing only after all succeed, or cleaning up already-written files on error.

Enjoy your invisible, uncommitted catalog entries in production.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/catalog/service.go
Line: 91-142

Comment:
**No tests for the new service layer**

Stop. You shipped the main mutation logic with zero tests. Nine tests for pure functions, none for the code that actually commits files to disk.

`ToggleWithDeps`, `toggleWithDepsEnable`, and `toggleWithDepsDisable` are entirely untested. `depgraph_test.go` covers the pure-function layer; `catalog_test.go` covers `List`/`Find`/`SetEnabled`. The service layer — enable-with-deps commit logic, force-disable check, `NoChange` semantics — has no coverage. Add tests for at least: enable with a missing dep, enable when dep is already enabled, disable blocked by a dependent, and disable with `--force`.

Untested mutation code is a time-delayed bug report.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/profile/profile_test.go
Line: 129-176

Comment:
**`TestApply_EnablesAppsOnDisk` skips the transitive dep path**

This test covers the old behavior and smugly calls it a day. Adding transitive dep resolution and forgetting to test it is a special kind of engineering bravery.

The test catalog entries have no `DependsOn` fields, so `Apply`'s new transitive dep expansion via `ResolveDeps` is never exercised. Add an entry with `DependsOn` (e.g. `postgresql` depending on `cnpg-operator`) and verify that calling `Apply` with only `["postgresql"]` also enables `cnpg-operator` and returns it in `autoAdded`.

At least the old catalog list behavior is bulletproof, I guess.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: enable path resolves deps even when..."](https://github.com/sikifanso/sikifanso/commit/118a40639f83435574da676af253e4510863b165) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27358485)</sub>

<!-- /greptile_comment -->