### PR TITLE
fix: add valkey to agent-minimal profile

### DIFF
--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -21,7 +21,8 @@ var registry = map[string]Profile{
 	"agent-minimal": {
 		Name:        "agent-minimal",
 		Description: "Bare minimum to route and observe LLM calls",
-		Apps:        []string{"litellm-proxy", "langfuse", "cnpg-operator", "postgresql"},
+		// valkey is required: langfuse uses it as a Redis-compatible session cache
+		Apps: []string{"litellm-proxy", "langfuse", "cnpg-operator", "postgresql", "valkey"},
 	},
 	"agent-full": {
 		Name:        "agent-full",


### PR DESCRIPTION
## Summary

- Adds `valkey` to the `agent-minimal` profile app list

## Why

Langfuse uses Valkey as a Redis-compatible session cache. Without it, Langfuse starts but fails to connect to Redis, producing confusing health errors. `agent-minimal` enables Langfuse, so it must also enable its Valkey dependency.

The `langfuse` catalog entry already lists `valkey` in its `dependsOn` (auto-enables it via `app enable`), but profiles bypass the `dependsOn` resolution and list apps explicitly.

## Test plan

- [ ] `go test ./internal/profile/... -race -count=1` passes
- [ ] `sikifanso cluster create --profile agent-minimal` deploys Valkey alongside Langfuse

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

**[Linus Torvalds Mode]** Somehow it took an entire pull request to add one string to a slice literal, but at least the fix is correct and the inline comment explaining *why* is genuinely useful for once. The `agent-minimal` profile was missing `"valkey"` in its `Apps` list, causing Langfuse to start successfully but immediately fail its Redis connection — a silent runtime breakage with a confusing health-check error and no obvious root cause.

- `"valkey"` added to `agent-minimal` `Apps` list (`internal/profile/profile.go:25`)
- The companion comment correctly documents the non-obvious dependency: Langfuse uses Valkey as a Redis-compatible session cache
- Consistent with `agent-full`, `agent-dev`, and `agent-safe`, which already carry `"valkey"`
- `rag` profile correctly omits `valkey` — it has no Langfuse dependency, so that is intentional
- Tests in `profile_test.go` reference `registry["agent-minimal"].Apps` dynamically (`TestResolve_SingleProfile`), so they pick up the fix without any modification needed

Congratulations on finding the one-liner that should have been in the original commit — try not to hurt yourself patting yourself on the back.

<h3>Confidence Score: 5/5</h3>

**[Linus Torvalds Mode]** It is one string added to a slice — I have seen more complexity in a Hello World program, and somehow this still needed a PR description with a test plan. Safe to merge; there is nothing here to break.

One string. The fix is correct and consistent with every other Langfuse-enabled profile already carrying valkey. The comment is accurate. Tests reference the registry dynamically and stay green automatically. There is no logic change, no API surface change, no migration, no risk. Perfect score, not because this is impressive work, but because there is literally nothing wrong with it.

profile.go is the only changed file and it needs zero attention — unless you somehow managed to break a string literal, in which case I have bigger concerns about this team.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/profile/profile.go | Adds `"valkey"` to the `agent-minimal` Apps slice; correct, consistent with all other Langfuse-enabled profiles, no test changes required. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["sikifanso cluster create\n--profile agent-minimal"] --> B["profile.Get(\"agent-minimal\")"] 
    B --> C["Apps resolved:\nlitellm-proxy, langfuse,\ncnpg-operator, postgresql, valkey"]
    C --> D["catalog.SetEnabled\nfor each app"]
    D --> E{App exists\nin catalog?}
    E -->|Yes| F["Write catalog/app.yaml\nenabled: true"]
    E -->|No| G["warn & skip"]
    F --> H["gitops.Commit"]
    G --> H
    style C fill:#d4edda,stroke:#28a745
    N1["⚠️ dependsOn resolution\nBYPASSED in profile mode\n— apps must be listed explicitly"]:::note
    classDef note fill:#fff3cd,stroke:#ffc107
```

<sub>Reviews (1): Last reviewed commit: ["profile: add valkey to agent-minimal"](https://github.com/sikifanso/sikifanso/commit/65e86235fb6a0efc1db4cc47d81b3b0632d47ad0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27370472)</sub>

<!-- /greptile_comment -->