### PR TITLE
fix: use OpEnable for post-profile sync on cluster create

### DIFF
--- a/cmd/sikifanso/cluster_create.go
+++ b/cmd/sikifanso/cluster_create.go
@@ -6,10 +6,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/alicanalbayrak/sikifanso/internal/argocd/appsetreconcile"
 	"github.com/alicanalbayrak/sikifanso/internal/argocd/grpcclient"
 	"github.com/alicanalbayrak/sikifanso/internal/argocd/grpcsync"
 	"github.com/alicanalbayrak/sikifanso/internal/cluster"
 	"github.com/alicanalbayrak/sikifanso/internal/gitops"
+	"github.com/alicanalbayrak/sikifanso/internal/kube"
 	"github.com/alicanalbayrak/sikifanso/internal/preflight"
 	"github.com/alicanalbayrak/sikifanso/internal/profile"
 	"github.com/alicanalbayrak/sikifanso/internal/prompt"
@@ -102,6 +104,10 @@ func clusterCreateAction(ctx context.Context, cmd *cli.Command) error {
 			zapLogger.Info("auto-enabled dependencies", zap.Strings("deps", autoAdded))
 		}
 		// Trigger ArgoCD sync so enabled apps deploy immediately.
+		// Use OpEnable: the catalog ApplicationSet hasn't reconciled yet, so the
+		// newly-enabled app CRs don't exist — OpSync against ListApplications would
+		// find nothing. OpEnable with ReconcileFn patches the AppSet annotation,
+		// waits for each CR to appear, then watches for Synced+Healthy.
 		client, connErr := grpcclient.FromSessionCreds(ctx,
 			sess.Services.ArgoCD.URL,
 			sess.Services.ArgoCD.Username,
@@ -111,17 +117,23 @@ func clusterCreateAction(ctx context.Context, cmd *cli.Command) error {
 			zapLogger.Warn("post-profile sync unavailable", zap.Error(connErr))
 		} else {
 			defer client.Close()
-			orch := grpcsync.NewOrchestrator(client, zapLogger)
-			listed, listErr := client.ListApplications(ctx)
-			if listErr != nil {
-				zapLogger.Warn("listing apps for post-profile sync failed", zap.Error(listErr))
+			restCfg, kubeErr := kube.RESTConfigForCluster(sess.ClusterName)
+			if kubeErr != nil {
+				zapLogger.Warn("post-profile sync: kube config unavailable", zap.Error(kubeErr))
 			} else {
-				names := make([]string, 0, len(listed))
-				for _, a := range listed {
-					names = append(names, a.Name)
-				}
-				if len(names) > 0 {
-					results, exitCode := orch.SyncAndWait(ctx, grpcsync.Request{Apps: names, Prune: true})
+				reconciler, recErr := appsetreconcile.NewReconciler(restCfg, "argocd")
+				if recErr != nil {
+					zapLogger.Warn("post-profile sync: reconciler unavailable", zap.Error(recErr))
+				} else {
+					orch := grpcsync.NewOrchestrator(client, zapLogger)
+					results, exitCode := orch.SyncAndWait(ctx, grpcsync.Request{
+						Apps:      profileApps,
+						Operation: grpcsync.OpEnable,
+						Prune:     true,
+						ReconcileFn: func(ctx context.Context) error {
+							return reconciler.Trigger(ctx, "catalog")
+						},
+					})
 					printSyncResults(os.Stderr, results)
 					if exitCode != grpcsync.ExitSuccess {
 						zapLogger.Warn("post-profile sync did not fully succeed", zap.Int("exitCode", int(exitCode)))

--- a/cmd/sikifanso/cluster_create.go
+++ b/cmd/sikifanso/cluster_create.go
@@ -127,7 +127,7 @@ func clusterCreateAction(ctx context.Context, cmd *cli.Command) error {
 				} else {
 					orch := grpcsync.NewOrchestrator(client, zapLogger)
 					results, exitCode := orch.SyncAndWait(ctx, grpcsync.Request{
-						Apps:      profileApps,
+						Apps:      append(profileApps, autoAdded...),
 						Operation: grpcsync.OpEnable,
 						Prune:     true,
 						ReconcileFn: func(ctx context.Context) error {


### PR DESCRIPTION
## Summary

- After `profile.Apply()` commits catalog YAMLs, the catalog ApplicationSet has not reconciled yet — newly-enabled app CRs don't exist as ArgoCD Application objects
- Previous code called `ListApplications` + `OpSync`: found nothing, deployed nothing
- Switch to `OpEnable` with a `ReconcileFn` that patches the catalog ApplicationSet annotation, then waits for each app CR to appear before watching for `Synced+Healthy`
- Matches the behaviour already used by `app enable` and `agent add` via `syncAfterMutation`

## Test plan

- [ ] `cluster create --profile agent-minimal` — verify litellm-proxy, langfuse, cnpg-operator, postgresql, valkey all deploy and reach Healthy
- [ ] `cluster create --profile rag` — verify qdrant, text-embeddings-inference, unstructured, cnpg-operator, postgresql all deploy
- [ ] `cluster create` with no profile — verify post-profile block is skipped entirely

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

**[Linus Torvalds Mode]** Oh look, it only took until now to figure out that you can't sync applications that don't exist yet — truly a groundbreaking insight that required an entire bug report to surface. I've seen better planning on a kindergarten finger-painting project than the original OpSync-on-nonexistent-app-CRs approach.

This PR switches the post-profile sync operation from `OpSync` to `OpEnable` after `profile.Apply()` commits catalog YAMLs. Since the ApplicationSet controller hasn't reconciled at that point, app CRs don't exist yet, and the old `OpSync + ListApplications` was finding nothing and silently accomplishing sweet nothing useful. The `OpEnable` path instead: (1) patches the "catalog" `ApplicationSet` annotation via a new `ReconcileFn` to trigger reconciliation, (2) spawns concurrent `waitForAppear` goroutines per app that poll until the app CR appears, trigger a sync, then watch for `Synced+Healthy`. It also resolves the previously flagged P1 where `autoAdded` dependency apps returned by `profile.Apply` were silently dropped — they're now correctly included via `append(profileApps, autoAdded...)`. All error paths (`grpc` connect, kube config, reconciler setup) are intentionally soft-fail: cluster creation proceeds even if post-profile sync goes sideways, which is a reasonable design choice.

At least you eventually got there — the bar for "correct behavior" remains on the floor, but congratulations on clearing it this time.

<h3>Confidence Score: 5/5</h3>

**[Linus Torvalds Mode]** What kind of kindergarten operation ships a sync-on-nonexistent-app-CRs bug in the first place — and then needs a separate bug report to notice that dependency apps were silently discarded from the wait list? Anyway, yes, this is safe to merge. Merge it before someone introduces a third regression.

The previous P1 (autoAdded silently dropped from the sync-wait app list) is now correctly addressed via append(profileApps, autoAdded...). The OpSync to OpEnable switch is architecturally correct: you cannot sync ArgoCD Application objects that the ApplicationSet controller has not created yet. The ReconcileFn patches the catalog ApplicationSet annotation to force reconciliation, waitForAppear polls until each app CR exists before triggering sync and watching for Synced+Healthy. Soft-fail error handling for grpc/kube/reconciler setup is deliberate and acceptable. All remaining observations are P2 style concerns that do not block merge.

Only cmd/sikifanso/cluster_create.go, and it is actually fine now — a marked improvement over its previous state.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/sikifanso/cluster_create.go | Switches post-profile sync to OpEnable with ReconcileFn; correctly includes autoAdded deps in sync-wait app list, resolving the previously reported P1 drop. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CA as clusterCreateAction
    participant PA as profile.Apply
    participant GC as grpcclient
    participant OR as SyncAndWait OpEnable
    participant RF as ReconcileFn
    participant AS as appsetreconcile.Trigger
    participant WA as waitForAppear per app
    participant AC as ArgoCD API

    CA->>PA: Apply(gitopsPath, profileStr, profileApps)
    PA-->>CA: profileApps, autoAdded
    CA->>CA: append(profileApps, autoAdded...)
    CA->>GC: FromSessionCreds(ctx)
    GC-->>CA: argocdClient
    CA->>OR: SyncAndWait(ctx, allApps, OpEnable, ReconcileFn)
    OR->>RF: ReconcileFn(ctx)
    RF->>AS: Trigger catalog patch AppSet annotation
    AS-->>OR: ok
    par for each app concurrently
        OR->>WA: go waitForAppear(app)
        loop poll every 5s until app CR exists
            WA->>AC: GetApplication(app)
            AC-->>WA: NotFound or found
        end
        WA->>AC: SyncApplication(app, prune=true)
        WA->>AC: WatchApplication(app)
        AC-->>WA: Synced+Healthy
        WA-->>OR: Result
    end
    OR-->>CA: results, exitCode soft-fail
```

<sub>Reviews (2): Last reviewed commit: ["fix: include auto-added dependency apps ..."](https://github.com/sikifanso/sikifanso/commit/6954b7341a4d57006871576e5149dedfbf3a403a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27371818)</sub>

<!-- /greptile_comment -->