### PR TITLE
fix: replace pollOnce fallback with pollUntilTerminal loop

### DIFF
--- a/docs/superpowers/plans/2026-04-04-argocd-deployment-research.md
+++ b/docs/superpowers/plans/2026-04-04-argocd-deployment-research.md
@@ -1,0 +1,25 @@
+# ArgoCD Deployment Research Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to execute this plan.
+
+**Goal:** Run five parallel specialist agents to identify reliability/UX problems in the sikifanso ArgoCD deployment pipeline and resource-sizing/shared-services problems across all homelab catalog apps, then synthesize findings into a prioritized problem report.
+
+**Architecture:** Five domain-expert agents run in parallel and write structured findings docs to `docs/superpowers/research/`. A synthesis agent reads all five docs and writes the final report to `docs/superpowers/reports/`.
+
+**Tech Stack:** Go (urfave/cli/v3, ArgoCD gRPC SDK, client-go), ArgoCD, k3d/k3s, Helm, Kubernetes
+
+---
+
+## Status: COMPLETED 2026-04-04
+
+All five agents ran and produced findings. Synthesis complete.
+
+**Output**:
+- `docs/superpowers/research/findings-argocd.md` — 9 findings (2 Critical, 3 High)
+- `docs/superpowers/research/findings-k8s.md` — 8 findings (1 Critical, 3 High)
+- `docs/superpowers/research/findings-go.md` — 9 findings (1 Critical, 3 High)
+- `docs/superpowers/research/findings-homelab.md` — 10 findings (1 Critical, 3 High)
+- `docs/superpowers/research/findings-appworkloads.md` — 19 findings (3 High)
+- `docs/superpowers/reports/2026-04-04-argocd-deployment-research-report.md` — 25 deduplicated problems, 4 cross-domain insights, 17 investigation tasks
+
+See the report for full details and investigation task list.

--- a/docs/superpowers/reports/2026-04-04-argocd-deployment-research-report.md
+++ b/docs/superpowers/reports/2026-04-04-argocd-deployment-research-report.md
@@ -1,0 +1,1268 @@
+# ArgoCD Deployment Research Report
+**Date**: 2026-04-04
+**Input**: 5 specialist findings documents (ArgoCD, K8s, Go, Homelab, AppWorkloads)
+
+---
+
+## Executive Summary
+
+The most critical problem in the sikifanso CLI is that `watchSingleApp` exits immediately
+on the first `Synced+Degraded` event and classifies it as a hard failure — but ArgoCD
+routinely produces `Synced+Degraded` for 5–60 seconds after a Helm sync completes while
+CRDs are establishing, PVCs are binding, and images are being pulled. This single issue is
+the direct cause of the observed `app enable postgresql` failure; the app self-healed
+minutes after the CLI reported failure. A second systemic defect amplifies the damage:
+the `cluster create` post-profile sync uses the wrong operation (`OpSync` with no
+`ReconcileFn`) against newly-enabled catalog apps that do not yet exist as ArgoCD
+Application CRs, meaning profile deployments silently skip the apps they are meant to
+deploy. On the catalog/infrastructure side, the Langfuse bundled ClickHouse and MinIO
+sub-charts carry no resource constraints, making their footprint opaque and uncontrolled;
+the `agent-full` profile's total memory request (~6.6 GiB declared, plus ~2 GiB infra
+overhead) risks OOM evictions on 8-16 GiB hosts. The three highest-priority investigation
+tasks are: **(T1) implement a Degraded grace-period window in `watchSingleApp`**, **(T2)
+fix the cluster-create post-profile sync to use `OpEnable` with AppSet reconciliation**,
+and **(T3) add resource constraints to Langfuse's ClickHouse and MinIO sub-charts**.
+
+---
+
+## Problem Catalog
+
+---
+
+### P1: watchSingleApp Exits Immediately on Transient Synced+Degraded
+**Severity**: Critical
+**Domains**: ArgoCD, K8s, Go
+**Affected scenarios**: `app enable` with any CRD-heavy chart (prometheus-stack,
+cert-manager, temporal); `app enable` with auto-enabled dependencies; any app with PVCs or
+slow image pulls on a constrained host.
+
+**Description**: When `watchSingleApp` receives a watch event showing
+`SyncStatus=Synced && Health=Degraded`, it immediately fetches the resource tree, calls
+`updateFn`, and returns. The parent `watchApps` maps `Health=Degraded` to `ExitFailure`,
+which `syncAfterMutation` surfaces to the user as `"sync failed: one or more apps
+unhealthy"`. ArgoCD routinely produces `Synced+Degraded` as a transient state immediately
+after a Helm sync because: (a) CRDs pass through `Degraded` ("CRD is not established") for
+5–30 seconds while the API server registers them; (b) PVCs in `WaitForFirstConsumer` mode
+are `Progressing` (contributing to aggregate `Degraded`) until a pod is scheduled and the
+image is pulled; (c) a single transient `ErrImagePull`/EOF causes the Pod and its parent
+Deployment to be `Degraded` even though kubelet will retry within 10–30 seconds. The fix
+comment at `orchestrator.go:152-153` acknowledges the `OutOfSync+Degraded` case was
+repaired but the `Synced+Degraded` transient window was not. The `SkipUnhealthy` field in
+`Request` (types.go:34) does not solve this — its semantics are "skip this app entirely",
+not "wait for it to stabilise".
+
+**Root cause**: `orchestrator.go:195` — exits unconditionally on
+`Health == "Degraded" && SyncStatus == "Synced"` with no minimum observation window or
+resource-type carve-outs. No grace period, no re-observation logic.
+
+**Impact**: Every first-time deployment of a CRD-heavy chart produces a false-negative
+CLI failure. The cluster self-heals but the user is left believing the operation failed,
+requiring a manual retry or cluster recreate.
+
+---
+
+### P2: Cluster Create Post-Profile Sync Uses Wrong Operation Against Non-Existent Apps
+**Severity**: Critical
+**Domains**: Go
+**Affected scenarios**: `cluster create --profile <any>` — the final sync step after
+`profile.Apply`.
+
+**Description**: After `profile.Apply` commits catalog YAML to the gitops repo,
+`cluster_create.go:115–129` calls `client.ListApplications()` and passes the result to
+`orch.SyncAndWait` with `OpSync` (the zero-value default). `OpSync` calls
+`SyncApplication` directly on each returned app name — it does not trigger AppSet
+reconciliation. At this point, the newly-enabled catalog apps exist only as YAML files in
+`catalog/*.yaml`; the ArgoCD ApplicationSet controller has not yet reconciled them into
+Application CRs. `ListApplications` therefore returns either an empty list (silent no-op)
+or only the root ApplicationSets themselves. When the list is empty, the `if len(names) > 0`
+guard silently skips the entire sync. The user sees the cluster creation complete
+successfully while none of the profile apps were actually deployed.
+
+**Root cause**: `cluster_create.go:115–129` — `ListApplications` + `OpSync` does not
+model the ArgoCD lifecycle correctly. Newly-enabled catalog apps require AppSet
+reconciliation (annotation patch) before they exist as Application CRs. The correct
+operation is `OpEnable` with a `ReconcileFn` pointing to the catalog ApplicationSet
+annotation trigger — identical to what `syncAfterMutation` does via `middleware.go:111–121`.
+
+**Impact**: Profile deployments via `cluster create` are silently incomplete. Users who
+rely on `--profile agent-dev` to get a working cluster will find apps are not deployed.
+
+---
+
+### P3: Catalog ApplicationSet Has No Automated SyncPolicy — Silent Stall Window
+**Severity**: Critical
+**Domains**: ArgoCD
+**Affected scenarios**: `app enable` / `app disable` for any catalog entry; any case where
+the manual `SyncApplication` call in `waitForAppear` is rejected.
+
+**Description**: `root-catalog.yaml` defines no `automated` block in its Application
+template. The sole sync driver for catalog apps is the manual `SyncApplication` call in
+`waitForAppear` (`orchestrator.go:241`). If that call arrives while ArgoCD is processing
+another reconcile cycle, or if the request is rejected (another operation already in
+flight), the app remains `OutOfSync` indefinitely — there is no background self-heal to
+recover it. This is inconsistent: `root-app.yaml` and `root-agents.yaml` both set
+`automated.selfHeal: true` / `prune: true`. The failed sync error is swallowed at Debug
+level: "sync trigger after appear failed (may already be syncing)".
+
+**Root cause**: `sikifanso-homelab-bootstrap/bootstrap/root-catalog.yaml:72-83` — `syncPolicy`
+block contains only `syncOptions` and `retry`; no `automated` key. Compare with
+`root-app.yaml:37-40` and `root-agents.yaml:37-40` which both set `automated.selfHeal: true`.
+
+**Impact**: If the `SyncApplication` call races with an ArgoCD reconcile (common during
+cluster bootstrap under load), the catalog app stalls `OutOfSync` until a user manually
+re-runs `app enable` or waits for the 180-second reconcile interval.
+
+---
+
+### P4: ArgoCD Webhook/gRPC Not Ready When CreateApplications Is Called After Install
+**Severity**: High
+**Domains**: K8s, ArgoCD
+**Affected scenarios**: `cluster create` — the `CreateApplications` call immediately after
+`argocd.Install` returns.
+
+**Description**: `waitForDeployments` in `install.go` polls `DeploymentAvailable` on three
+ArgoCD deployments and returns as soon as all pass. `Available=True` is set once a pod's
+readiness probe passes (HTTP GET `/healthz` on port 8080). However, the ArgoCD admission
+webhook (which the Kubernetes API server routes through for `argoproj.io` resources) and
+the gRPC service initialise asynchronously after the pod passes its readiness probe — they
+require loading the application cache, establishing informer watches, and registering TLS
+certs. `CreateApplications` is called immediately after `waitForDeployments` returns and
+issues a dynamic Kubernetes `Create` call that routes through the webhook. If the webhook
+is not yet bound, the API server returns `connection refused` or `dial timeout` as an
+unretried hard error, halting cluster creation.
+
+**Root cause**: `install.go:70-73` — no gRPC-level readiness check after
+`waitForDeployments`. `cluster.go:172-192` — `argocd.Install` is followed immediately by
+`argocd.CreateApplications` with no intermediate probe.
+
+**Impact**: Intermittent `cluster create` failures that are timing-dependent and hard to
+reproduce. More common on slow hosts or under Docker Desktop resource contention.
+
+---
+
+### P5: post-profile Sync and cluster create use Hardcoded ~/.kube/config
+**Severity**: High
+**Domains**: ArgoCD, K8s
+**Affected scenarios**: Multi-cluster setups; `cluster create` on a machine with an active
+non-sikifanso kubeconfig context; `app enable` where `CreateApplications` is called.
+
+**Description**: Both `waitForDeployments` (`install.go:91-98`) and `CreateApplications`
+(`applications.go:44-52`) independently call
+`clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)`, which reads
+`~/.kube/config` and uses whatever context is currently active. `appsetreconcile/reconcile.go`
+correctly accepts `*rest.Config` as a parameter. `cluster.go:148-154` writes the kubeconfig
+and updates the current context immediately before these calls, so the race window is small
+in a single-cluster workflow. In a multi-cluster scenario, if the user has switched context
+or another process has changed it between the kubeconfig write and the API calls,
+`CreateApplications` silently targets the wrong cluster.
+
+**Root cause**: `applications.go:44` — `clientcmd.RecommendedHomeFile` is hardcoded; no
+cluster name or session path is threaded through. `install.go:91` — same pattern. The
+`*rest.Config` returned by `KubeconfigGetWrite` is discarded at `cluster.go:148-154`
+instead of being passed to subsequent calls.
+
+**Impact**: In a multi-cluster workflow, ArgoCD Application CRDs can be created in the
+wrong cluster with no error or warning. Silent data misrouting.
+
+---
+
+### P6: RollingSync Tier Ordering Declared in ApplicationSet but Ignored by CLI and Absent from Most Apps
+**Severity**: High
+**Domains**: ArgoCD, AppWorkloads
+**Affected scenarios**: `app enable` with multiple apps spanning tiers; `cluster create`
+with any profile that includes both `0-operators` and `2-services` tier apps.
+
+**Description**: `root-catalog.yaml` is configured with `strategy.type: RollingSync`
+across three tiers: `0-operators`, `1-data`, `2-services`. ArgoCD will not begin syncing
+tier-1 until all tier-0 apps are `Healthy`. However, the CLI's `watchApps`
+(`orchestrator.go:96-115`) launches a goroutine per app concurrently with no
+tier-awareness. Tier-1 and tier-2 apps held back by ArgoCD's RollingSync will appear as
+`OutOfSync/Unknown` to the CLI's watchers, which maps to `ExitTimeout` — even though
+ArgoCD is doing exactly the right thing. Compounding this, 14 of 19 catalog apps have no
+`tier` or `dependsOn` field at all, so they are applied in an unordered batch alongside
+tier-0 operators. Specifically: `valkey` (a shared service that langfuse depends on) has
+no tier; `litellm-proxy` has no tier despite runtime coupling to langfuse and ollama;
+`alloy` has no tier despite hardcoded loki/tempo endpoint dependencies; `loki` and `tempo`
+have no tier even though alloy depends on them.
+
+**Root cause (two-part)**:
+1. `orchestrator.go:96-115` — concurrent per-app goroutines, no tier sequencing.
+2. Catalog YAML: `valkey.yaml`, `litellm-proxy.yaml`, `alloy.yaml`, `loki.yaml`,
+   `tempo.yaml` (and 9 others) — missing `tier` and `dependsOn` fields.
+
+**Impact**: Concurrent startup is fragile for apps with boot-time service dependencies.
+The CLI reports spurious timeouts for apps legitimately held in the RollingSync queue. On
+a constrained node, all apps compete for resources simultaneously rather than in ordered
+waves.
+
+---
+
+### P7: agent-minimal Profile Missing valkey — Langfuse Fails Redis Connection on Startup
+**Severity**: High
+**Domains**: AppWorkloads
+**Affected scenarios**: `cluster create --profile agent-minimal`; `sikifanso app enable langfuse`
+without first enabling valkey.
+
+**Description**: The `agent-minimal` profile enables `[litellm-proxy, langfuse, cnpg-operator,
+postgresql]`. Langfuse's values file configures `redis.deploy: false` and
+`redis.host: valkey.storage.svc.cluster.local`, meaning it expects the shared valkey
+instance to be running. valkey is not in the `agent-minimal` app list, so it will not be
+deployed. Langfuse will start, fail its Redis connection check, and either refuse requests
+or produce errors on every trace submission. The `langfuse.yaml` catalog entry also does
+not list `valkey` in its `dependsOn`, so ArgoCD will not enforce the ordering.
+
+**Root cause**: `internal/profile/profile.go:22-25` — agent-minimal app list omits valkey.
+`catalog/langfuse.yaml:10-12` — `dependsOn: [cnpg-operator, postgresql]` does not include
+valkey. `catalog/values/langfuse.yaml:29-34` — `redis.deploy: false`, wired to shared valkey.
+
+**Impact**: `agent-minimal` is a documented entry profile; its deployment failure on
+langfuse is a user-visible regression affecting the simplest on-boarding path.
+
+---
+
+### P8: Langfuse Bundled ClickHouse and MinIO Have No Resource Constraints
+**Severity**: High
+**Domains**: Homelab, AppWorkloads
+**Affected scenarios**: Any profile including langfuse (`agent-minimal`, `agent-dev`,
+`agent-safe`, `agent-full`); `app enable langfuse`.
+
+**Description**: The langfuse values file sets resources only for the main application
+container (256Mi request / 1Gi limit). Two bundled sub-charts — ClickHouse
+(`clickhouse.deploy: true`) and MinIO (`s3.deploy: true`) — inherit upstream defaults with
+no homelab overrides. ClickHouse defaults to a 2 GiB memory request with no limit; under
+analytical query load it rises to 4-12 GiB. MinIO typically allocates 256–512 MiB. Neither
+has limits set, so a single langfuse deployment can silently consume most of the cluster's
+available memory — and was the direct cause of the Langfuse OOM failure noted in the spec
+("ClickHouse requesting ~12 GB on a single homelab node"). Additionally, there is no
+standalone `clickhouse` or `minio` catalog entry, so these services cannot be shared across
+apps or independently managed.
+
+**Root cause**: `sikifanso-homelab-bootstrap/catalog/values/langfuse.yaml:37-58` —
+`clickhouse.deploy: true` and `s3.deploy: true` with no `resources:` stanza under either
+sub-chart. ClickHouse upstream chart default: 2 GiB memory request, no limit.
+
+**Impact**: Langfuse deployment causes OOM evictions on nodes with less than 6-8 GiB free.
+On a constrained single-node cluster, enabling langfuse can destabilise all other apps
+running on the same node.
+
+---
+
+### P9: Presidio Analyzer Memory Limit Causes OOM on Startup
+**Severity**: High
+**Domains**: AppWorkloads, Homelab
+**Affected scenarios**: `app enable presidio`; any profile including presidio (`agent-safe`,
+`agent-full`).
+
+**Description**: The Presidio analyzer container loads spaCy `en_core_web_lg` at startup.
+This model requires 700-800 MiB of RSS before processing a single request. The values file
+sets `limits.memory: 512Mi` for the analyzer, which is less than the model's minimum
+working set. The container will be OOM-killed before it finishes initialising. The anonymizer
+(128Mi request / 256Mi limit) is fine as it is purely rule-based.
+
+**Root cause**: `sikifanso-homelab-bootstrap/catalog/values/presidio.yaml` — analyzer
+`limits.memory: 512Mi`. Microsoft Presidio Docker image bundles `en_core_web_lg` by
+default; `en_core_web_lg` loaded RSS: 700-800 MiB.
+
+**Impact**: Presidio will never successfully start. Any profile or user that enables
+presidio will see a CrashLoopBackOff that cannot self-heal regardless of wait time.
+
+---
+
+### P10: gRPC Stream Fallback pollOnce Provides a Single Stale Snapshot
+**Severity**: Medium
+**Domains**: ArgoCD, Go
+**Affected scenarios**: Any `watchSingleApp` call where the gRPC stream drops mid-sync
+(network hiccup, ArgoCD pod restart, Docker bridge connection-tracking timeout).
+
+**Description**: When the gRPC watch stream closes unexpectedly, `watchSingleApp` falls
+back to a single `pollOnce` call and returns. If `GetApplication` catches the app in any
+transient intermediate state (`OutOfSync/Progressing`, mid-sync), that state is recorded
+as the final result, producing a spurious timeout or false health report. A zeroed result
+(when `GetApplication` also fails) has `Health == ""` and `SyncStatus == ""`, which falls
+into the `default` branch of `watchApps` exit-code logic as `ExitTimeout` with no
+indication to the user that the watch failed mid-stream. The asymmetry with
+`waitForDisappear` is notable: that function uses `pollUntilGone` (a loop), not
+`pollOnce`.
+
+**Root cause**: `orchestrator.go:167-170` — `case event, ok := <-eventCh:` with
+`if !ok { o.pollOnce(...); return }`. `orchestrator.go:320-336` — `pollOnce` calls
+`updateFn(Result{App: name})` (zeroed) on error.
+
+**Impact**: Stream drops on slow or loaded clusters cause silent misclassification of sync
+results. The gRPC connection has no keep-alive (`client.go:44-85`), making stream drops
+more likely on Docker's internal bridge network.
+
+---
+
+### P11: waitForAppear Polling Starts After First Tick — Always Waits ≥5s
+**Severity**: Medium
+**Domains**: ArgoCD, Go
+**Affected scenarios**: `app enable` with fast-reconciling ApplicationSets; every
+`OpEnable` path.
+
+**Description**: `waitForAppear` creates a ticker and immediately enters a `select` that
+blocks until the first tick fires (`orchestrator.go:219-237`). The tick interval is
+`DefaultPollInterval = 5 * time.Second` (`types.go:12`). This means the function always
+waits at least 5 seconds before checking whether the Application CR exists — even if the
+AppSet controller has already reconciled and created it within 1 second of the annotation
+patch. Additionally, `Trigger()` in `appsetreconcile/reconcile.go:45-56` patches the
+annotation and returns immediately with no confirmation that the controller acted on it;
+`waitForAppear` never checks for annotation removal (which is the controller's signal that
+reconciliation ran), so it may start polling before the controller has had any chance to
+respond.
+
+**Root cause**: `orchestrator.go:215-235` — ticker-first loop with no initial `GetApplication`
+check. `appsetreconcile/reconcile.go:45-56` — `Trigger` returns immediately after PATCH;
+no poll for annotation removal.
+
+**Impact**: Adds unnecessary latency to every `app enable`. Masks annotation patch failures:
+if `Trigger()` errors, execution continues and `waitForAppear` blocks for its full timeout
+with no clear message that the root cause was a failed annotation patch.
+
+---
+
+### P12: SyncApplication Called After waitForAppear Without Operation-State Guard
+**Severity**: Medium
+**Domains**: ArgoCD
+**Affected scenarios**: `app enable` for `root` and `agents` ApplicationSet apps (which
+have `automated.selfHeal: true`).
+
+**Description**: `waitForAppear` calls `SyncApplication` unconditionally as soon as
+`GetApplication` returns a non-NotFound result (`orchestrator.go:241`). For `root` and
+`agents` ApplicationSets, the Application is created with `automated.selfHeal: true /
+prune: true`, meaning ArgoCD's controller may already have started an automatic sync.
+Sending a manual `SyncApplication` while ArgoCD's internal operation is `Running` produces
+a gRPC error ("another operation is already in progress"), currently swallowed at Debug
+level. The manual sync request can also disrupt a carefully-ordered CRD-before-workload
+sync sequence, causing resource-ordering failures.
+
+**Root cause**: `orchestrator.go:241-243` — `SyncApplication` called unconditionally; error
+is Debug-logged with message "may already be syncing".
+
+**Impact**: Redundant sync triggers on auto-sync apps; potential disruption of in-flight
+syncs for complex charts.
+
+---
+
+### P13: Error Messages Discard All Available Context
+**Severity**: Medium
+**Domains**: Go
+**Affected scenarios**: Any sync failure or timeout — interactive terminal and CI pipelines.
+
+**Description**: `syncAfterMutation` receives the full `[]grpcsync.Result` slice with
+per-resource health details (app name, SyncStatus, Health, Message, Resources), but the
+error messages returned to the user contain only static strings:
+`"sync failed: one or more apps unhealthy"` or
+`"sync timed out: apps may still be reconciling"`. The user is given no indication of
+which app failed, what its health/sync state was, or which resources are degraded. The
+`printSyncResults` call has the data but produces stderr output before the error is
+returned — in CI or when output is piped, this detail is lost.
+
+**Root cause**: `middleware.go:136-151` — error construction uses only static strings;
+`results` is ignored. `grpcsync/types.go:39-46` — `Result` carries `App`, `SyncStatus`,
+`Health`, `Message`, `Resources` — all discarded.
+
+**Impact**: Users and CI pipelines cannot determine why a sync failed without grepping
+detailed logs. Increases support burden and time-to-diagnosis.
+
+---
+
+### P14: watchApps Default Branch Conflates Progressing and Unknown Exit States
+**Severity**: Medium
+**Domains**: Go
+**Affected scenarios**: Any sync that times out while an app is `Progressing`, `Unknown`,
+or `Suspended`.
+
+**Description**: The `watchApps` exit-code logic (`orchestrator.go:127-143`) has three
+cases: success (`Synced+Healthy` or `Deleted`), explicit failure (`Degraded` or `Missing`),
+and a `default` branch that maps everything else to `ExitTimeout`. The `default` covers
+`Progressing`, `Unknown`, `Suspended`, and any future ArgoCD health states. An app that is
+`Unknown` because ArgoCD lost contact with the cluster is indistinguishable from an app
+that is legitimately `Progressing` mid-sync. Both produce `ExitTimeout` and the same
+"sync timed out" message. `Unknown` state typically indicates a connectivity or cluster
+health problem that warrants a louder and different signal.
+
+**Root cause**: `orchestrator.go:134-143` — `default` case maps to `ExitTimeout`.
+`middleware.go:149-150` — both timeout cases produce identical messages.
+
+**Impact**: Users cannot distinguish transient progress delays from cluster connectivity
+failures, leading to incorrect remediation attempts.
+
+---
+
+### P15: Spinner Suffix Is a Data Race Under Concurrent Watches
+**Severity**: Medium
+**Domains**: Go
+**Affected scenarios**: `app enable` with multiple apps syncing concurrently (the common
+case for auto-deps).
+
+**Description**: `watchApps` spawns one goroutine per app (`orchestrator.go:96-115`). Each
+goroutine calls `req.OnProgress`, which directly assigns `s.Suffix` in the outer
+`syncAfterMutation` closure (`middleware.go:114-120`). The spinner library does not protect
+`Suffix` with a mutex in its public API — the background spinner goroutine reads `s.Suffix`
+on every tick while the watch goroutines write it. Running `go test -race` on any
+`app enable` with two or more apps will surface this as a data race on `s.Suffix`. Beyond
+the race, the suffix is overwritten by whichever goroutine fires last, so earlier progress
+from other apps is silently lost.
+
+**Root cause**: `middleware.go:103` and `middleware.go:114-120` — single spinner with
+unprotected `Suffix` written from multiple goroutines simultaneously.
+
+**Impact**: Data race; undefined behavior in Go. In practice the spinner shows only the
+most recently reported app, dropping progress information for all others.
+
+---
+
+### P16: ReconcileFn Error Is Swallowed, Causing Full-Timeout Block on Patch Failure
+**Severity**: Medium
+**Domains**: Go
+**Affected scenarios**: `app enable` with a transient AppSet annotation patch failure.
+
+**Description**: `ReconcileFn` (the AppSet annotation patch) is called once at the start
+of `OpEnable`/`OpDisable` (`orchestrator.go:43-55`). If the patch fails,
+`SyncAndWait` logs a warning and continues into `watchApps`. `watchApps` then blocks for
+the full context timeout (typically 5-10 minutes) waiting for apps that will never appear
+because the ApplicationSet was never told to reconcile them. There is no retry and no early
+exit.
+
+**Root cause**: `orchestrator.go:43-46` — `ReconcileFn` error is only logged as `Warn`,
+not returned. `appsetreconcile/reconcile.go:48-52` — `Trigger` returns an error on patch
+failure; the error is silently downgraded.
+
+**Impact**: A transient RBAC hiccup or API server blip causes the entire `app enable`
+operation to block silently for its full timeout before reporting failure.
+
+---
+
+### P17: All Root ApplicationSets Start Concurrently on cluster create — Resource Contention
+**Severity**: Medium
+**Domains**: K8s
+**Affected scenarios**: `cluster create` on a constrained single-node k3d host (< 16 GiB RAM).
+
+**Description**: After `CreateApplications`, `gitops.ApplyRootApp` applies all three root
+ApplicationSets simultaneously (`cluster.go:195-197`). ArgoCD reconciles all of them at
+once, meaning Cilium, ArgoCD itself, and any catalog entries already `enabled: true` all
+compete for image pull bandwidth, container runtime scheduling, etcd write throughput, and
+CPU during the same 2-3 minute window. This amplifies every transient failure described in
+P1 — CRD establishment races, PVC binding delays, and image pull EOFs all occur
+concurrently rather than sequentially, increasing the probability of a false-negative CLI
+exit.
+
+**Root cause**: `cluster.go:195-197` — `gitops.ApplyRootApp` is called with no sequencing
+against the Cilium and ArgoCD Application syncs.
+
+**Impact**: On an 8 GiB host, simultaneous startup of all enabled apps routinely produces
+OOM pressure and cascading `Synced+Degraded` states that trigger P1's false-negative.
+
+---
+
+### P18: ResourceTree Used for Failure Diagnostics Misses Sync Error Messages
+**Severity**: Medium
+**Domains**: ArgoCD
+**Affected scenarios**: Any failed sync — the `✗` resource detail shown in terminal output.
+
+**Description**: When `watchSingleApp` detects `Synced+Degraded`, it calls `ResourceTree`
+(`orchestrator.go:197`) to populate `r.Resources` for display. `ResourceTree` maps
+`tree.Nodes` to `ResourceStatus`, but `tree.Nodes` have no `SyncStatus` field — only
+health. The more useful per-resource sync errors (e.g. "hook failed", "resource already
+exists") are in `app.Status.Resources`, which is returned by `GetApplication` and already
+mapped by `toResourceStatuses`. The `ResourceTree` call is also more expensive (full graph
+fetch) and leaves the `Status` field of `ResourceStatus` empty, so any unhealthy-but-synced
+resources are silent in terminal output.
+
+**Root cause**: `grpcclient/applications.go:154-181` — `ResourceTree` maps `tree.Nodes`
+with no `Status` (sync) field. `grpcclient/types.go:40-48` — `ResourceStatus.Status` is
+left empty by the ResourceTree path.
+
+**Impact**: Failure diagnostics show health errors but not sync errors, making triage
+harder and causing engineers to miss the most actionable failure reason.
+
+---
+
+### P19: gRPC Connection Has No Keep-Alive — Silent Dead Streams Under Docker Bridge
+**Severity**: Medium
+**Domains**: ArgoCD
+**Affected scenarios**: Long-running watches (slow Helm charts, large resource counts,
+cluster under load).
+
+**Description**: The gRPC client is created with plain `apiclient.ClientOptions` and no
+additional `DialOptions`. No `keepalive.ClientParameters` are configured. In a k3d cluster
+running inside Docker, the bridge network's connection-tracking can silently drop idle TCP
+connections (no events for > ~20s). When this happens, `stream.Recv()` blocks until the
+next event or context cancellation rather than returning an error immediately — the `!ok`
+channel-close branch is never triggered. The `WatchApplication` channel buffer of 16 is
+also not monitored for exhaustion.
+
+**Root cause**: `grpcclient/client.go:44-85` — no `grpc.WithKeepaliveParams`,
+no `grpc.WithBlock`, no `grpc.WithReturnConnectionError`.
+`grpcclient/applications.go:125-148` — tight `Recv` loop; silently-dead stream blocks
+indefinitely.
+
+**Impact**: On a Docker Desktop host under memory pressure, long syncs can silently stall
+mid-watch with no fallback to polling, making the CLI appear hung.
+
+---
+
+### P20: agent-full Profile Exceeds Safe Memory Envelope for 8-16 GiB Hosts
+**Severity**: Medium
+**Domains**: Homelab
+**Affected scenarios**: `cluster create --profile agent-full`; enabling all 19 catalog apps
+simultaneously.
+
+**Description**: The `agent-full` profile enables all 19 catalog apps. Declared memory
+requests total ~6.6 GiB (excluding Langfuse bundled sub-charts). Adding Cilium (~300 MiB),
+ArgoCD (~500 MiB), CoreDNS + k3d overhead (~150 MiB), and Langfuse's unconstrained
+ClickHouse (~500 MiB minimum), total system pressure reaches 8-9 GiB on declared requests
+alone. On an 8 GiB host the OOM killer will evict pods under any load spike. Total PVC
+allocation reaches 89 GiB, which may exhaust local-path storage on developer laptops.
+
+**Root cause**: `internal/profile/profile.go:29-37` — all 19 apps listed. No preflight
+memory check before applying the profile.
+
+**Impact**: `agent-full` is unreliable on the primary target hardware class (developer
+laptop, 8-16 GiB RAM, Docker Desktop).
+
+---
+
+### P21: Temporal Helm Values Only Set Top-Level server.resources — Four Services Go Unconstrained
+**Severity**: Medium
+**Domains**: Homelab, AppWorkloads
+**Affected scenarios**: `app enable temporal`; any profile including temporal.
+
+**Description**: The Temporal Helm chart deploys four separate server components
+(frontend, history, matching, worker), each as its own Deployment. The values file sets
+only a single `server.resources` block. In practice, each Temporal service pod runs
+independently and the chart defines separate `frontend`, `history`, `matching`, `worker`
+top-level keys each accepting their own `resources` and `replicaCount`. Without per-service
+overrides, actual cluster consumption is likely 4× the declared 256 MiB request.
+Additionally, Temporal values do not include `elasticsearch.enabled: false`, and the chart
+may render Elasticsearch schema jobs by default, which will CrashLoop on a cluster without
+Elasticsearch.
+
+**Root cause**: `catalog/values/temporal.yaml:4-13` — single `server.resources` block;
+no per-service breakdown. No `elasticsearch.enabled: false`.
+
+**Impact**: Temporal's actual footprint is significantly larger than reported. On a
+constrained node, the four Temporal service pods will compete for unallocated resources
+and may trigger the OOM killer.
+
+---
+
+### P22: Prometheus PVC Oversized at 20 GiB — Combined PVC Footprint Reaches 89 GiB
+**Severity**: Medium
+**Domains**: Homelab
+**Affected scenarios**: Any profile including prometheus-stack; `agent-full`; `agent-dev`.
+
+**Description**: Prometheus is configured with `retention: 7d` and a 20 GiB storage claim.
+For a single-node homelab scraping 20-40 pods, 7-day retention typically consumes 1-3 GiB.
+The 20 GiB figure is likely copied from a production template. Combined with Ollama's 20 GiB
+model PVC, Loki's 10 GiB, Tempo's 10 GiB, PostgreSQL's 10 GiB, Qdrant's 10 GiB,
+AlertManager's 5 GiB, Grafana's 2 GiB, and Valkey's 2 GiB, total PVC allocation reaches
+89 GiB for the full profile. Additionally, there is no `retentionSize` guard — Prometheus
+will silently fill the full PVC regardless of the time-based retention policy.
+
+**Root cause**: `catalog/values/prometheus-stack.yaml:23-25` — `storage: 20Gi` with no
+`retentionSize`.
+
+**Impact**: Developer laptops with 256-512 GB SSDs may not comfortably accommodate 89 GiB
+of PVC allocations alongside Docker images and OS files.
+
+---
+
+### P23: Agent Sandbox ResourceQuota Conflates Requests and Limits — Forces Guaranteed QoS
+**Severity**: Medium
+**Domains**: Homelab, AppWorkloads
+**Affected scenarios**: All agent sandbox deployments via `sikifanso agent create`.
+
+**Description**: The ResourceQuota template hard-sets `requests.cpu`, `limits.cpu`,
+`requests.memory`, and `limits.memory` all to the same value (`agent.cpu` and
+`agent.memory`). This forces every container in the agent namespace to set requests equal
+to limits to satisfy the quota, placing all agent pods in `Guaranteed` QoS class. This
+prevents Burstable QoS (request < limit) for orchestration agents that have variable CPU
+usage patterns. A 500m CPU / 512 MiB memory quota also leaves no headroom for auxiliary
+containers (sidecars, init containers) within the same namespace.
+
+**Root cause**: `sikifanso-agent-template/templates/resourcequota.yaml:9-14` — `limits.cpu`
+and `requests.cpu` both set to `{{ .Values.agent.cpu }}`.
+`sikifanso-agent-template/values.yaml:4-8` — single values used for both requests and
+limits quota.
+
+**Impact**: Agent workloads requiring burst CPU (e.g., local inference calls) are throttled
+to their request ceiling. Init containers count against the quota, causing scheduling
+failures for multi-container agent pods.
+
+---
+
+### P24: cnpg-operator Has No Resource Requests or Limits
+**Severity**: Low
+**Domains**: Homelab
+**Affected scenarios**: All profiles (cnpg-operator is a dependency of postgresql which is
+in every profile).
+
+**Description**: The cnpg-operator values file sets `replicaCount: 1`, `crds.create: true`,
+and `config.clusterWide: true`, but contains no `resources:` stanza. All other
+operator-style apps in the catalog (external-secrets, opa) have explicit resources set.
+Without bounds, an operator bug or high reconciliation load could consume unbounded memory.
+
+**Root cause**: `catalog/values/cnpg-operator.yaml` — no `resources:` key.
+
+**Impact**: Unbounded resource consumption on a single-node cluster with no QoS isolation.
+Low risk in practice (the CNPG operator is well-behaved), but inconsistent with catalog
+conventions.
+
+---
+
+### P25: nemo-guardrails Has No LLM Endpoint Configured — App Will Fail to Apply Any Rail
+**Severity**: Low
+**Domains**: AppWorkloads
+**Affected scenarios**: `app enable nemo-guardrails`; `agent-safe` and `agent-full` profiles.
+
+**Description**: NeMo Guardrails is a Python server that invokes an LLM to evaluate safety
+rules. The values file sets no `llm.endpoint` or `openai.*` wiring. Without an LLM endpoint
+configured, NeMo Guardrails will start but will fail to apply any LLM-backed rail
+(responding with errors on any guarded request). There is also no `dependsOn: [litellm-proxy]`
+in the catalog entry, so the intended upstream LLM proxy may not be ready when nemo-guardrails
+starts.
+
+**Root cause**: `catalog/values/nemo-guardrails.yaml` — no LLM endpoint configuration.
+`catalog/nemo-guardrails.yaml` — no `dependsOn`.
+
+**Impact**: nemo-guardrails deploys successfully but is non-functional out of the box.
+Confusing UX for first-time users of the agent-safe profile.
+
+---
+
+## Cross-Domain Insights
+
+---
+
+### CDX-1: Synced+Degraded False-Negative Has Three Compounding Causes Across Domains
+**Domains involved**: ArgoCD, K8s, Go
+
+**The interaction**: Three independently-observed findings all describe the same user-visible
+failure (`"sync failed: one or more apps unhealthy"` for a self-healing app), but from
+different angles:
+
+- **ArgoCD** (Finding 1): `orchestrator.go:195` exits on the first `Synced+Degraded`
+  watch event with no observation window. ArgoCD's health model does not distinguish
+  "resources still initialising" from "permanent failure."
+- **K8s** (Findings 2, 3, 4, 5): CRDs pass through `Establishing/Degraded` for 5-30s;
+  PVCs in `WaitForFirstConsumer` mode are `Progressing` until pod scheduling; image pull
+  EOFs on Docker Desktop cause `Degraded` Deployments that kubelet retries within 30s.
+  All of these are normal first-sync behaviour on a single-node k3d cluster.
+- **Go** (Finding 1): The exit point is in `watchApps` (`orchestrator.go:134-138`) which
+  maps `Health == "Degraded"` to `ExitFailure` with no grace period. The `// FIX` comment
+  in the source acknowledges this but the implementation remains.
+
+**Combined fix direction**: A single `DegradedGracePeriod` field (default 60s) in the
+`Request` type, checked in `watchSingleApp`: on the first `Synced+Degraded` event, start a
+timer rather than returning. If the app transitions to `Synced+Healthy` before the timer
+fires, report success. If the timer expires while still `Degraded`, call `ResourceTree` and
+report failure. This single change resolves the confirmed production defect with minimal
+structural impact. Optionally, classify degraded sub-resource types (CRD `Establishing`,
+PVC `Progressing`) as explicitly transient to exit even faster once all non-transient
+resources are healthy.
+
+---
+
+### CDX-2: RollingSync Tier Ordering Is Partially Declared and Entirely Ignored by the CLI
+**Domains involved**: ArgoCD, AppWorkloads
+
+**The interaction**: `root-catalog.yaml` declares `strategy.type: RollingSync` with three
+ordered tiers, which is architecturally correct — operators first, data services second,
+application services third. However, 14 of 19 catalog apps have no `tier` label, so they
+fall into an unordered batch alongside tier-0 operators. The apps that are missing tiers
+are not arbitrary: `valkey` is a shared service that `langfuse` depends on at boot time;
+`litellm-proxy` hard-codes `LANGFUSE_HOST` and `ollama` endpoints; `alloy` hardcodes loki
+and tempo endpoints. These missing labels mean the RollingSync strategy provides no
+protection for the most fragile dependencies. Independently, the CLI's `watchApps` watches
+all apps concurrently with no tier awareness, so even for apps that do have `tier` labels,
+the CLI reports spurious `ExitTimeout` for tier-2 apps that are intentionally held by
+ArgoCD until tier-0 is healthy.
+
+**Combined fix direction**: Two changes required:
+1. **Catalog YAML**: add `tier` and `dependsOn` to the 14 apps missing them (see T6 for
+   the full list). Priority: `valkey` → tier-1 data; `loki`, `tempo` → tier-1 data;
+   `alloy` → tier-2 with `dependsOn: [loki, tempo]`; `litellm-proxy` → tier-2 with
+   `dependsOn: [langfuse, ollama]`; `nemo-guardrails` → tier-2 with
+   `dependsOn: [litellm-proxy]`.
+2. **CLI**: modify `watchApps` to be tier-aware — start watching tier-0 apps first, then
+   release tier-1 watchers only after all tier-0 apps reach `Synced+Healthy`. The
+   `catalog.Entry.Tier` field is already populated at the CLI layer; it needs to be
+   threaded into the `Request` type and used to sequence goroutine launches.
+
+---
+
+### CDX-3: Langfuse ClickHouse and MinIO Bundling Creates an Unconstrained OOM Hazard
+**Domains involved**: Homelab, AppWorkloads
+
+**The interaction**: The Homelab agent found that the Langfuse sub-charts have no resource
+constraints, noting ClickHouse defaults to 2 GiB RAM with no limit. The AppWorkloads agent
+found that there is no standalone `clickhouse` or `minio` catalog entry, so these services
+are permanently bundled — they cannot be shared, independently scaled, or separately
+constrained. Together these create a situation where: (a) any deployment of langfuse
+silently provisions unconstrained ClickHouse and MinIO alongside it; (b) there is no
+observable catalog entry to modify or replace; (c) the memory footprint is opaque and can
+fill all available RAM on a constrained node before any OOM protection triggers.
+
+**Combined fix direction**: Two parallel changes:
+1. **Immediate**: add `clickhouse.resources` and `s3.resources` overrides to
+   `catalog/values/langfuse.yaml`. For ClickHouse: `requests.memory: 512Mi`,
+   `limits.memory: 1Gi`; tune `clickhouse.settings.max_memory_usage` to match. For
+   MinIO: `requests.memory: 128Mi`, `limits.memory: 256Mi`.
+2. **Strategic**: create standalone `clickhouse` and `minio` catalog entries
+   (`tier: 1-data`) and update langfuse to point at them via `clickhouse.host` and
+   `s3.endpoint` value overrides. The `project_langfuse_deps.md` memory note aligns with
+   this direction.
+
+---
+
+### CDX-4: Hardcoded ~/.kube/config Across ArgoCD Install and Application Creation
+**Domains involved**: ArgoCD, K8s
+
+**The interaction**: The ArgoCD agent found `applications.go:44` uses
+`clientcmd.RecommendedHomeFile` (the global kubeconfig) rather than the session's
+cluster-specific config. The K8s agent found the same pattern in `install.go:91-98`. Both
+call sites independently re-resolve the kubeconfig from `~/.kube/config` rather than
+accepting the `*rest.Config` that `cluster.go:148-154` already has available immediately
+after `KubeconfigGetWrite`. The pattern in `appsetreconcile/reconcile.go:31-38` — which
+correctly accepts `*rest.Config` as a parameter — shows the right approach is already
+established in the codebase.
+
+**Combined fix direction**: A single refactor: change both `Install` and `CreateApplications`
+signatures to accept `*rest.Config` as a parameter, and pass the config obtained from
+`KubeconfigGetWrite` at `cluster.go:148-154` through to both call sites. This eliminates
+two independent TOCTOU races between context-switch and API calls, and makes both functions
+testable without a real cluster.
+
+---
+
+## Investigation Task List
+
+---
+
+### T1: Implement Degraded Grace Period in watchSingleApp
+**Priority**: Critical
+**Related problems**: P1, CDX-1
+**Domain**: Go (ArgoCD orchestrator)
+**Files/configs to examine**:
+  - `internal/argocd/grpcsync/orchestrator.go` — `watchSingleApp` function, lines 154-210;
+    the `Synced+Degraded` exit branch at line 195; the `watchApps` exit-code mapping at
+    lines 127-143
+  - `internal/argocd/grpcsync/types.go` — `Request` struct (add `DegradedGracePeriod
+    time.Duration`); `DefaultPollInterval` constant
+  - `cmd/sikifanso/middleware.go` — `syncAfterMutation` — where `Request` is constructed;
+    what `SkipUnhealthy` is currently set to
+
+**Specific questions to answer**:
+  1. Does adding `DegradedGracePeriod` to the `Request` struct break any existing callers
+     that construct `Request` directly (not through `SyncAndWait`)? List all construction
+     sites.
+  2. Should the grace period be per-app (each app gets its own timer) or global (the first
+     Degraded app starts one shared timer)? What is the correct behaviour when app A goes
+     Degraded, recovers, and then app B goes Degraded?
+  3. What should `watchSingleApp` do if `ctx` expires while the grace period timer is still
+     running — return `ExitTimeout` or `ExitFailure`?
+  4. Is it safe to call `ResourceTree` only after the grace period expires, or does the
+     result become stale if the app recovered and then degraded again?
+  5. Confirm whether `OperationState.Phase == "Succeeded" && Health == "Degraded"` (sync
+     completed, resources still converging) is reliably distinguishable from
+     `OperationState.Phase == "Failed" && Health == "Degraded"` (sync itself failed) via
+     `GetApplication` — if so, document the fast-exit path for genuine failures.
+
+**Definition of done**: A `DegradedGracePeriod` is wired into `watchSingleApp` such that
+the confirmed failure scenario (prometheus-stack `Synced+Degraded` during CRD
+establishment, PVC binding, image pull retry) no longer produces `ExitFailure`. A new test
+case in `grpcsync/` simulates a sequence of
+`Synced+Degraded → ... → Synced+Healthy` events and asserts success.
+
+---
+
+### T2: Fix cluster create Post-Profile Sync to Use OpEnable with AppSet Reconciliation
+**Priority**: Critical
+**Related problems**: P2
+**Domain**: Go (cluster_create.go)
+**Files/configs to examine**:
+  - `cmd/sikifanso/cluster_create.go` — lines 115-129; the `ListApplications` +
+    `SyncAndWait` block; confirm what is in `names` at this point in execution
+  - `cmd/sikifanso/middleware.go` — `syncAfterMutation` function (lines 100-155);
+    how it constructs `Request` with `OpEnable` and `ReconcileFn`
+  - `internal/argocd/grpcsync/orchestrator.go` — `OpEnable` path (lines 57-80);
+    `OpSync` path (lines 57-64)
+  - `internal/profile/profile.go` — `Apply` return value and what app names it has access
+    to after committing YAML
+
+**Specific questions to answer**:
+  1. Does `profile.Apply` return or have access to the list of app names it enabled? If not,
+     what is the cleanest way to extract them (parse the returned catalog entries, or add a
+     return value to `Apply`)?
+  2. What `ReconcileFn` should be used — the same annotation-patch trigger used by
+     `syncAfterMutation`? Is there already a constructor for it, or must it be constructed
+     inline?
+  3. Should the post-profile sync use `OpEnable` or `OpSync` for apps that may already exist
+     as Application CRs from a previous partial run? Confirm the idempotency contract.
+  4. Is the timeout used in `cluster_create.go` for this sync appropriate given that it may
+     need to wait for multi-tier RollingSync sequencing?
+
+**Definition of done**: `cluster create --profile agent-dev` on a fresh cluster results in
+all profile apps being deployed (not silently skipped). A manual test or integration test
+confirms that the `ReconcileFn` is called and that `waitForAppear` is reached for each
+newly-enabled app.
+
+---
+
+### T3: Add Resource Constraints to Langfuse Bundled ClickHouse and MinIO
+**Priority**: Critical
+**Related problems**: P8, CDX-3
+**Domain**: Homelab
+**Files/configs to examine**:
+  - `sikifanso-homelab-bootstrap/catalog/values/langfuse.yaml` — lines 37-58;
+    `clickhouse.deploy: true` and `s3.deploy: true` sections; confirm the exact Helm value
+    paths for sub-chart resource overrides
+  - Langfuse Helm chart source (referenced chart: `langfuse/langfuse`) — check
+    `values.yaml` schema for `clickhouse.resources` and `s3.resources` nesting
+  - `project_langfuse_deps.md` memory note — confirms strategic direction for standalone
+    catalog entries
+
+**Specific questions to answer**:
+  1. What is the exact Helm value path to set resource requests/limits for the bundled
+     ClickHouse sub-chart? (e.g. `clickhouse.resources.requests.memory` or nested differently)
+  2. What is the minimum ClickHouse memory setting that allows Langfuse to function for
+     homelab-scale event volumes (< 1000 events/day)? Verify `clickhouse.settings.max_memory_usage`
+     is the correct parameter.
+  3. Does the bundled MinIO sub-chart accept a standard `resources:` override, or does it
+     use a different value path?
+  4. Is `clickhouse.auth.password: changeme` the same static password issue as MinIO's
+     `rootPassword: changeme`? If so, document both as needing a secret management
+     strategy before production use.
+
+**Definition of done**: Langfuse can be enabled on an 8 GiB node without triggering OOM
+evictions on other pods. ClickHouse and MinIO both have explicit memory limits that prevent
+unconstrained growth. The fix is verified by checking `kubectl top pods -n langfuse` after
+a steady-state deployment.
+
+---
+
+### T4: Add Automated SyncPolicy to Catalog ApplicationSet
+**Priority**: Critical
+**Related problems**: P3
+**Domain**: ArgoCD
+**Files/configs to examine**:
+  - `sikifanso-homelab-bootstrap/bootstrap/root-catalog.yaml` — lines 72-83; the
+    `syncPolicy` block in the Application template
+  - `sikifanso-homelab-bootstrap/bootstrap/root-app.yaml` — lines 37-40; reference
+    implementation of `automated.selfHeal: true / prune: true`
+  - `sikifanso-homelab-bootstrap/bootstrap/root-agents.yaml` — lines 37-40; same
+
+**Specific questions to answer**:
+  1. Is the absence of `automated` in `root-catalog.yaml` intentional? Check git history
+     or any inline comment explaining the asymmetry with `root-app` and `root-agents`.
+  2. If `automated.selfHeal: true` is added, does the manual `SyncApplication` call in
+     `waitForAppear` need to be changed — or can it remain as an accelerator that no longer
+     needs to be the sole recovery mechanism?
+  3. Does adding `automated.prune: true` to the catalog ApplicationSet create any risk for
+     the local-hostPath gitops pattern (e.g., pruning resources that exist in the cluster
+     but whose YAML was temporarily absent due to a gitops repo reset)?
+
+**Definition of done**: `root-catalog.yaml` has `automated.selfHeal: true` (and optionally
+`prune: true`) in the Application template, consistent with the other two ApplicationSets.
+A note documenting the intent is added as a YAML comment.
+
+---
+
+### T5: Fix Hardcoded ~/.kube/config in Install and CreateApplications
+**Priority**: High
+**Related problems**: P5, CDX-4
+**Domain**: K8s / ArgoCD (shared refactor)
+**Files/configs to examine**:
+  - `internal/argocd/install.go` — line 91; `waitForDeployments` kubeconfig resolution
+  - `internal/argocd/applications.go` — line 44; `CreateApplications` kubeconfig resolution
+  - `internal/cluster/cluster.go` — lines 148-154; `KubeconfigGetWrite` return value
+    handling; where `Install` and `CreateApplications` are called
+  - `internal/argocd/appsetreconcile/reconcile.go` — lines 31-38; reference implementation
+    that correctly accepts `*rest.Config`
+
+**Specific questions to answer**:
+  1. Does `KubeconfigGetWrite` return a `*rest.Config` or does it need to be separately
+     obtained? If not, what is the cleanest way to get the `*rest.Config` for the just-created
+     cluster — `clientcmd.NewDefaultClientConfigLoadingRules().Load()` with cluster name
+     validation, or `k3dclient.KubeconfigGet` + `clientcmd.RESTConfigFromKubeConfig`?
+  2. List every call site of `Install` and `CreateApplications` — how many callers need
+     to be updated when the signature changes?
+  3. Are there any tests that mock `clientcmd.RecommendedHomeFile` — if so, how do they
+     need to change?
+
+**Definition of done**: Both `Install(ctx, cfg *rest.Config, ...)` and
+`CreateApplications(ctx, cfg *rest.Config, ...)` accept an explicit `*rest.Config`. The
+global kubeconfig is not read inside either function. Multi-cluster operation is safe.
+
+---
+
+### T6: Add Missing tier and dependsOn Labels to 14 Catalog Entries
+**Priority**: High
+**Related problems**: P6, CDX-2
+**Domain**: AppWorkloads
+**Files/configs to examine**:
+  - `sikifanso-homelab-bootstrap/catalog/valkey.yaml` — add `tier: 1-data`
+  - `sikifanso-homelab-bootstrap/catalog/loki.yaml` — add `tier: 1-data`
+  - `sikifanso-homelab-bootstrap/catalog/tempo.yaml` — add `tier: 1-data`
+  - `sikifanso-homelab-bootstrap/catalog/alloy.yaml` — add `tier: 2-services`,
+    `dependsOn: [loki, tempo]`
+  - `sikifanso-homelab-bootstrap/catalog/litellm-proxy.yaml` — add `tier: 2-services`,
+    `dependsOn: [langfuse, ollama]`
+  - `sikifanso-homelab-bootstrap/catalog/nemo-guardrails.yaml` — add `tier: 2-services`,
+    `dependsOn: [litellm-proxy]`
+  - `sikifanso-homelab-bootstrap/catalog/langfuse.yaml` — add `dependsOn: [valkey]`
+    (already has `tier: 2-services`)
+  - `sikifanso-homelab-bootstrap/bootstrap/root-catalog.yaml` — confirm RollingSync step
+    definitions include `tier: 1-data` as an explicit step
+
+**Specific questions to answer**:
+  1. Does `root-catalog.yaml` RollingSync currently have a `tier: 1-data` step, or only
+     `0-operators` and `2-services`? If `1-data` is absent, adding `tier: 1-data` to apps
+     without a matching ApplicationSet step will have no effect — the step must also be
+     declared.
+  2. What is the correct `dependsOn` format in the catalog YAML — is it a list of app
+     names, ArgoCD Application names, or label selectors? Verify against the ApplicationSet
+     generator template.
+  3. Should `opa`, `external-secrets`, and `prometheus-stack` be assigned explicit tier
+     labels? They are currently in tier-0 but without labels. Confirm whether unlabelled
+     apps are treated as tier-0 by default or as an unordered concurrent batch.
+
+**Definition of done**: All 14 apps have `tier` and `dependsOn` fields where applicable.
+`root-catalog.yaml` has all three tier steps defined. A cold-start deployment of
+`agent-dev` shows valkey healthy before langfuse attempts its Redis connection.
+
+---
+
+### T7: Add valkey to agent-minimal Profile and langfuse dependsOn
+**Priority**: High
+**Related problems**: P7
+**Domain**: AppWorkloads
+**Files/configs to examine**:
+  - `sikifanso/internal/profile/profile.go` — lines 22-25; agent-minimal app list
+  - `sikifanso-homelab-bootstrap/catalog/langfuse.yaml` — lines 10-12; `dependsOn` list
+  - `sikifanso-homelab-bootstrap/catalog/values/langfuse.yaml` — lines 29-34; confirm
+    `redis.deploy: false` and `redis.host: valkey.storage.svc.cluster.local`
+
+**Specific questions to answer**:
+  1. Is `valkey` already enabled in the gitops repo's catalog when `agent-minimal` is
+     applied, or does the profile need to enable it? Distinguish between "valkey is
+     `enabled: true` in the catalog baseline" vs "valkey must be explicitly added to the
+     profile app list to be enabled."
+  2. Does the `agent-minimal` profile total memory request remain within the safe 8 GiB
+     envelope after adding valkey (valkey requests only 64 MiB)?
+  3. Are there any other apps in `agent-minimal` that have undeclared runtime service
+     dependencies besides langfuse → valkey?
+
+**Definition of done**: `cluster create --profile agent-minimal` results in langfuse
+successfully connecting to valkey on startup. `catalog/langfuse.yaml` lists `valkey` in
+`dependsOn`. No other silent missing dependency in the agent-minimal profile.
+
+---
+
+### T8: Fix presidio Analyzer Memory Limit to Accommodate spaCy en_core_web_lg
+**Priority**: High
+**Related problems**: P9
+**Domain**: AppWorkloads / Homelab
+**Files/configs to examine**:
+  - `sikifanso-homelab-bootstrap/catalog/values/presidio.yaml` — analyzer resources block;
+    confirm current `limits.memory: 512Mi`
+  - Presidio Helm chart (`presidio/presidio`, chart version in the catalog entry) —
+    confirm value path for per-component resource overrides; check whether a smaller
+    spaCy model (`en_core_web_sm`) can be configured via a Helm value
+
+**Specific questions to answer**:
+  1. Does the `presidio/presidio` Helm chart support a `--spacy-model` or equivalent
+     Helm value to select `en_core_web_sm` instead of `en_core_web_lg`? If so, document
+     the value path and the memory reduction.
+  2. What is the minimum memory limit that allows the analyzer to start without OOM kill
+     when using `en_core_web_lg`? Target: 1 GiB limit based on 700-800 MiB observed RSS.
+  3. Does the total memory request for `agent-safe` remain within the safe envelope after
+     raising the analyzer limit?
+
+**Definition of done**: Presidio analyzer starts and passes its readiness probe on first
+deployment without OOM kill. Either the memory limit is raised to 1 GiB or the spaCy model
+is switched to `en_core_web_sm` with the smaller limit justified by evidence.
+
+---
+
+### T9: Replace pollOnce Stream Fallback with pollWithRetry Loop
+**Priority**: Medium
+**Related problems**: P10
+**Domain**: Go (ArgoCD orchestrator)
+**Files/configs to examine**:
+  - `internal/argocd/grpcsync/orchestrator.go` — `pollOnce` call at lines 167-170;
+    `pollOnce` implementation at lines 320-336; `pollUntilGone` at approximately lines
+    252-278 (reference implementation)
+  - `internal/argocd/grpcclient/applications.go` — `WatchApplication` goroutine, lines
+    125-148; the `stream.Recv()` error path that closes the channel
+
+**Specific questions to answer**:
+  1. When `WatchApplication`'s `eventCh` closes with `!ok`, what does the calling
+     `watchSingleApp` know about why the channel closed — is there any way to distinguish
+     a clean stream end from a network error at this call site?
+  2. Should the retry loop log a warning to the user that the watch stream dropped and
+     polling has taken over? What log level and message is appropriate?
+  3. Is there a risk that the retry loop produces a final `Synced+Healthy` result from a
+     stale poll after the app has already been deleted (race between poll and delete)?
+
+**Definition of done**: When the gRPC watch stream closes unexpectedly mid-sync,
+`watchSingleApp` enters a polling loop (retrying at `DefaultPollInterval`) until the app
+reaches a terminal state or `ctx` expires. A log warning informs the user that polling
+mode is active.
+
+---
+
+### T10: Implement Tier-Aware watchApps Goroutine Sequencing
+**Priority**: Medium
+**Related problems**: P6, CDX-2
+**Domain**: Go (ArgoCD orchestrator)
+**Files/configs to examine**:
+  - `internal/argocd/grpcsync/orchestrator.go` — `watchApps` function, lines 82-149;
+    goroutine launch loop at lines 96-115
+  - `internal/argocd/grpcsync/types.go` — `Request` struct; `AppRequest` (per-app
+    sub-request if it exists); confirm whether `Tier` is already in the request model
+  - `internal/catalog/catalog.go` — `Entry` struct, line 25; confirm `Tier` field and
+    its type
+
+**Specific questions to answer**:
+  1. Is the `Tier` field from `catalog.Entry` currently threaded into the `grpcsync.Request`
+     at any call site? If not, which call sites need to be updated to pass it?
+  2. What should `watchApps` do if an app has no `Tier` field — treat it as tier-0, tier-2,
+     or a special "unordered" bucket?
+  3. Can the tier-sequencing logic reuse the existing `watchSingleApp` function unchanged,
+     or does it require changes to how results are propagated back to the caller?
+  4. How should the timeout interact with tier sequencing — should each tier get a fraction
+     of the total timeout, or should the timeout be per-tier-batch?
+
+**Definition of done**: `watchApps` sequences goroutine launches by tier: all tier-0
+apps are watched first; tier-1 goroutines start only after all tier-0 apps reach
+`Synced+Healthy`; tier-2 starts after tier-1 completes. Apps with no tier are placed in
+the tier-0 bucket by default. Existing tests pass.
+
+---
+
+### T11: Add ArgoCD gRPC Readiness Probe After waitForDeployments
+**Priority**: Medium
+**Related problems**: P4
+**Domain**: K8s / ArgoCD
+**Files/configs to examine**:
+  - `internal/argocd/install.go` — `waitForDeployments` function, lines 70-133; the
+    return point at line 70-73
+  - `internal/cluster/cluster.go` — lines 172-192; gap between `argocd.Install` and
+    `argocd.CreateApplications`
+  - `internal/argocd/grpcclient/client.go` — available methods; check whether a
+    `GetVersion` or `ServerVersion` gRPC call is available for use as a readiness ping
+
+**Specific questions to answer**:
+  1. Does the ArgoCD gRPC client expose a no-side-effect health or version endpoint that
+     can be used as a readiness ping? (e.g., `argocd.io/v1alpha1` `version` endpoint or
+     equivalent gRPC method.)
+  2. What is the appropriate retry interval and maximum duration for the readiness probe?
+     (Suggested: 2s interval, 30s max, based on observed ArgoCD startup time on k3d.)
+  3. Does adding the gRPC probe cause issues if ArgoCD TLS is not yet configured — does
+     the probe need to handle `insecure` mode consistent with the rest of the client?
+
+**Definition of done**: `cluster create` no longer fails intermittently with
+`connection refused` on `CreateApplications`. The gRPC probe retries with exponential
+backoff and logs progress. The maximum probe duration is configurable.
+
+---
+
+### T12: Fix Startup ApplicationSet Sequencing in cluster create
+**Priority**: Medium
+**Related problems**: P17
+**Domain**: K8s
+**Files/configs to examine**:
+  - `internal/cluster/cluster.go` — `gitops.ApplyRootApp` call at lines 195-197; the
+    ordering of Cilium, ArgoCD Application syncs, and the root ApplicationSet apply
+  - `internal/argocd/grpcsync/orchestrator.go` — whether a `WaitForApps(names []string)`
+    primitive exists or needs to be added
+
+**Specific questions to answer**:
+  1. After `ApplyRootApp`, is there any wait for Cilium's Application to reach
+     `Synced+Healthy` before proceeding? If not, what is the correct point in `cluster.go`
+     to insert this gate?
+  2. Is the Cilium Application name stable and known at compile time, or is it derived
+     from the gitops repo content?
+  3. Can the existing `watchApps` be reused to implement a
+     `WaitForApps(ctx, names)` that blocks until named apps are healthy — without
+     triggering any new syncs?
+
+**Definition of done**: `cluster create` on a constrained (8 GiB RAM) host shows Cilium
+reaching `Synced+Healthy` before catalog entries begin syncing. OOM pressure during
+bootstrap is measurably reduced.
+
+---
+
+### T13: Build Actionable Error Messages from grpcsync.Result Slice
+**Priority**: Medium
+**Related problems**: P13
+**Domain**: Go
+**Files/configs to examine**:
+  - `cmd/sikifanso/middleware.go` — `syncAfterMutation`, lines 136-155; static error
+    string construction; `printSyncResults` at lines 156-183
+  - `internal/argocd/grpcsync/types.go` — `Result` struct, lines 39-46; available fields
+
+**Specific questions to answer**:
+  1. Should the per-app failure details be embedded in the returned `error` value, or in a
+     separate structured log line? What format works best for both interactive terminal and
+     CI JSON log output?
+  2. For `ExitTimeout`, the app may still be reconciling — should the error message
+     distinguish "apps that were `Progressing` at timeout" from "apps that were
+     `Unknown`/`Degraded` at timeout"?
+  3. Is there a character limit or line-count concern for embedding multiple app statuses
+     in a single error string for terminal display?
+
+**Definition of done**: When `app enable` fails, the error message includes the name of
+the failing app(s), their `SyncStatus`, `Health`, and at least the first degraded resource
+message. CI log output retains this information without requiring a separate stderr block.
+
+---
+
+### T14: Fix Spinner Data Race and Multi-App Progress Display
+**Priority**: Medium
+**Related problems**: P15
+**Domain**: Go
+**Files/configs to examine**:
+  - `cmd/sikifanso/middleware.go` — `syncAfterMutation`, lines 100-125; spinner
+    construction at line 103; `OnProgress` closure at lines 114-120
+  - `internal/argocd/grpcsync/orchestrator.go` — goroutine launch in `watchApps`,
+    lines 96-115; `req.OnProgress` call sites
+
+**Specific questions to answer**:
+  1. Does the spinner library used (`github.com/briandowns/spinner` or similar) expose a
+     thread-safe `Suffix` setter? If so, can it be used as a drop-in fix without changing
+     the rendering model?
+  2. What is the simplest multi-app progress display that fits the existing CLI UX? Options:
+     (a) single-line spinner showing "3/5 apps synced", (b) multi-line status with one line
+     per app, (c) channel-based renderer. Which minimises changes to existing `OnProgress`
+     contract?
+  3. Confirm that `go test -race ./cmd/sikifanso/...` currently surfaces this race and
+     that the fix eliminates it.
+
+**Definition of done**: `go test -race ./cmd/sikifanso/...` passes cleanly (no race
+detected). Users watching `app enable` with 3+ apps see progress for all apps, not just
+the last one to update.
+
+---
+
+### T15: Constrain Temporal to Four Per-Service Resource Blocks and Disable Elasticsearch
+**Priority**: Medium
+**Related problems**: P21
+**Domain**: Homelab / AppWorkloads
+**Files/configs to examine**:
+  - `sikifanso-homelab-bootstrap/catalog/values/temporal.yaml` — full file; current
+    `server.resources` block; confirm which Helm values control per-service resources
+  - Temporal Helm chart source (`go.temporal.io/helm-charts`, version matching catalog
+    entry) — `values.yaml` for `frontend`, `history`, `matching`, `worker` top-level keys;
+    `elasticsearch` sub-chart default enabled state
+
+**Specific questions to answer**:
+  1. Does `server.resources` in the temporal chart apply to all four services or only to
+     a wrapper? Check chart `_helpers.tpl` or equivalent to confirm which template actually
+     uses this value.
+  2. What is the minimum per-service resource configuration for a single-node homelab
+     with light temporal workloads (1-2 workflows in flight)?
+  3. Is `elasticsearch.enabled: false` sufficient to prevent schema migration jobs from
+     running, or is there an additional `schema.update.enabled: false` needed?
+
+**Definition of done**: Temporal values file has explicit `frontend.resources`,
+`history.resources`, `matching.resources`, and `worker.resources` blocks. Elasticsearch
+sub-chart is explicitly disabled. `kubectl describe pods -n temporal` shows all four
+service pods respecting their configured limits.
+
+---
+
+### T16: Reduce Prometheus PVC to 5 GiB and Add retentionSize Guard
+**Priority**: Medium
+**Related problems**: P22
+**Domain**: Homelab
+**Files/configs to examine**:
+  - `sikifanso-homelab-bootstrap/catalog/values/prometheus-stack.yaml` — `storage: 20Gi`
+    line 23-25; `retention: 7d` lines 18-20; `prometheusSpec` section
+
+**Specific questions to answer**:
+  1. What is the correct Helm value path for `retentionSize` under the
+     `kube-prometheus-stack` chart — is it `prometheusSpec.retentionSize` or a different
+     nesting?
+  2. Should AlertManager's 5 GiB PVC also be reduced? What is the typical AlertManager
+     state storage requirement for a homelab cluster with no long-term silence/inhibition
+     state?
+  3. After reducing Prometheus to 5 GiB and AlertManager to 1 GiB, does total PVC
+     allocation drop to a manageable level for an `agent-dev` profile?
+
+**Definition of done**: Prometheus PVC is 5 GiB with `retentionSize: "4GB"` configured.
+AlertManager PVC is 1 GiB. Total PVC allocation for `agent-dev` profile is documented.
+
+---
+
+### T17: Separate ResourceQuota Requests and Limits in agent-template
+**Priority**: Medium
+**Related problems**: P23
+**Domain**: Homelab / AppWorkloads
+**Files/configs to examine**:
+  - `sikifanso-agent-template/templates/resourcequota.yaml` — lines 9-14; current quota
+    field mapping
+  - `sikifanso-agent-template/values.yaml` — lines 4-8; `cpu` and `memory` single values
+  - `internal/agent/` in `sikifanso/` — how `agent create` passes cpu/memory values to
+    the Helm chart; what flags are exposed to the user
+
+**Specific questions to answer**:
+  1. What is the correct Kubernetes ResourceQuota field semantics for allowing Burstable
+     pods — should only `limits.cpu` and `limits.memory` be set (omitting request-side
+     quota), or should requests quota be set at a lower value than limits quota?
+  2. Does `sikifanso agent create` expose `--cpu` and `--memory` flags? If so, do they
+     currently set both request and limit to the same value?
+  3. Are there existing agent workloads or tests that would break if the quota fields are
+     changed?
+
+**Definition of done**: Agent namespace ResourceQuota allows Burstable QoS (request <
+limit). The `agent create` command exposes separate `--cpu-request`/`--cpu-limit` flags or
+documents sensible defaults for orchestration vs inference workloads.
+
+---
+
+## Out of Scope
+
+The following observations were identified during the review but are deliberately deferred:
+
+- **Standalone ClickHouse and MinIO catalog entries** (CDX-3 strategic direction): Creating
+  new catalog entries requires design decisions about versioning, chart selection, and
+  Langfuse wiring that go beyond the scope of a resource-constraints fix. Deferred to a
+  dedicated feature session after T3 (immediate constraints) is complete.
+
+- **Local registry mirror / image pre-pull DaemonSet** (K8s Finding 5): Pre-pulling images
+  reduces the probability of EOF-triggered `Degraded` states but is infrastructure
+  complexity that should be evaluated after T1 (grace period) eliminates false negatives.
+  Deferred.
+
+- **PgBouncer catalog entry** (AppWorkloads Finding 13, max_connections risk): The
+  max_connections=200 ceiling is a real concern under agent-full, but requires a new
+  catalog entry and connection string changes in langfuse and temporal values. Deferred
+  until actual connection exhaustion is observed.
+
+- **WatchApplication goroutine cleanup on ctx cancel** (Go Finding 6): The race is largely
+  theoretical because gRPC propagates context cancellation through the stream. The residual
+  risk (non-blocking ctx poll pattern) is low-severity polish. Deferred.
+
+- **Ollama memory request vs realistic working set** (AppWorkloads Finding 7 / Homelab
+  Finding 6): Raising ollama's request from 1 GiB to 2 GiB is correct but has no
+  functional impact on a single-node cluster (scheduler always places on the one node).
+  Deferred to a resource-sizing consolidation session.
+
+- **Loki filesystem storage durability** (AppWorkloads Finding 9): Log loss on cluster
+  recreate is a documented characteristic of the homelab design, not a bug. Deferred until
+  a shared MinIO catalog entry exists to offer an upgrade path.
+
+- **text-embeddings-inference CPU-only throughput** (AppWorkloads Finding 8): CPU-mode TEI
+  throughput is a performance concern, not a reliability defect. Deferred.
+
+- **Prometheus scrape interval and TSDB tuning** (Homelab Finding 8): The
+  `retentionSize` guard is included in T16; further TSDB tuning (scrape interval, head
+  compaction) is deferred.
+
+- **opa / qdrant / prometheus-stack tier label additions** (AppWorkloads Findings 14-16):
+  These are informational-only dependency concerns with no runtime boot-order risk for
+  current profiles. Deferred as low-priority catalog hygiene.

--- a/docs/superpowers/research/findings-appworkloads.md
+++ b/docs/superpowers/research/findings-appworkloads.md
@@ -1,0 +1,366 @@
+# App Workloads Audit — sikifanso Homelab Bootstrap
+
+**Date**: 2026-04-04
+**Scope**: All 19 catalog apps in `sikifanso-homelab-bootstrap/catalog/`
+**Cluster type**: Single-node k3d homelab, no GPU assumed unless noted
+
+---
+
+## Shared-Services Audit
+
+| App | Bundles PostgreSQL | Bundles Redis | Bundles S3/MinIO | Bundles ClickHouse | Bundles Other | Can Use Shared? |
+|-----|--------------------|---------------|------------------|--------------------|---------------|-----------------|
+| alloy | No | No | No | No | No | N/A |
+| cnpg-operator | No | No | No | No | No | N/A |
+| external-secrets | No | No | No | No | No | N/A |
+| guardrails-ai | No | No | No | No | No | N/A |
+| langfuse | **deploy: false** (wired to shared) | **deploy: false** (wired to shared) | **Yes — deploy: true** (bundled MinIO) | **Yes — deploy: true** (bundled ClickHouse) | No | PostgreSQL + Valkey: already shared. MinIO + ClickHouse: bundled, no standalone catalog entry yet |
+| litellm-proxy | No | No | No | No | No | N/A — but has implicit runtime dep on Langfuse + Ollama |
+| loki | No | No | **minio.enabled: false** (explicitly disabled, filesystem used) | No | No | N/A |
+| nemo-guardrails | No | No | No | No | No | N/A |
+| ollama | No | No | No | No | No | N/A |
+| opa | No | No | No | No | No | N/A |
+| postgresql | No (IS the shared PostgreSQL) | No | No | No | No | N/A |
+| presidio | No | No | No | No | No | N/A |
+| prometheus-stack | No | No | No | No | No | N/A |
+| qdrant | No | No | No | No | No | N/A |
+| temporal | **postgresql.enabled: false** (wired to shared) | No | No | No | cassandra.enabled: false, mysql.enabled: false | PostgreSQL: already shared. No Redis dep. |
+| tempo | No | No | No | No | No | N/A |
+| text-embeddings-inference | No | No | No | No | No | N/A |
+| unstructured | No | No | No | No | No | N/A |
+| valkey | No | No | No | No | No | N/A (IS the shared Valkey) |
+
+---
+
+## Executive Summary
+
+Seven of the 19 catalog apps are pure infrastructure services (cnpg-operator, postgresql, valkey, prometheus-stack, external-secrets, opa, alloy) with no bundled dependencies. The main shared-service concern is langfuse, which bundles both ClickHouse and MinIO as internal subcharts — together these add approximately 1–2 GiB of memory overhead on a single-node cluster and neither has a standalone catalog entry. Temporal and langfuse both correctly disable their internal PostgreSQL/Redis subcharts and wire to the shared cluster services. Dependency ordering is partially covered via the `tier`/`dependsOn` mechanism, but a majority of apps (14 of 19) have no `tier` or `dependsOn` field, relying entirely on ArgoCD retry/selfHeal for ordering — this is fragile for apps with hard boot-time database dependencies. The agent sandbox ResourceQuota defaults (500m CPU / 512Mi memory) are appropriate for a lightweight orchestration agent but are too small for any agent that drives local inference inline.
+
+---
+
+## Finding 1: Langfuse Bundles ClickHouse — Significant Memory Overhead, No Shared Alternative
+
+**Severity**: High
+**Domain**: AppWorkloads
+**Affected app**: langfuse
+**Root cause hypothesis**: Langfuse v3 requires ClickHouse for its analytics pipeline (event ingestion, usage tracking). There is no standalone `clickhouse` catalog entry, so the chart deploys a bundled single-node ClickHouse instance. The `langfuse.yaml` values file acknowledges this with the comment "required for Langfuse v3 analytics".
+**Evidence**:
+- `catalog/values/langfuse.yaml` lines 37–41: `clickhouse.deploy: true` with `auth.password: changeme`
+- ClickHouse single-node minimum memory is ~500 MiB at rest, rising to 1–2 GiB under any analytical query load
+- No `clickhouse.yaml` entry exists in `catalog/` — ClickHouse cannot be shared between apps today
+**Cross-domain flag**: yes — ClickHouse is a candidate for a new standalone catalog entry (storage tier), and langfuse would benefit from pointing at it
+**Investigation direction**: Evaluate adding a `clickhouse` catalog entry (Bitnami or Altinity chart, `tier: 1-data`, `dependsOn: cnpg-operator` not applicable but needs ordering before langfuse). Assess whether Langfuse's ClickHouse usage can be pointed at an external host via `clickhouse.host`/`clickhouse.port` values overrides. Verify memory footprint of `clickhouse/clickhouse` vs `bitnami/clickhouse` on a constrained node.
+
+---
+
+## Finding 2: Langfuse Bundles MinIO — Prevents Future Shared Object Store
+
+**Severity**: High
+**Domain**: AppWorkloads
+**Affected app**: langfuse
+**Root cause hypothesis**: Langfuse v3 requires S3-compatible storage for event blobs and media uploads. There is no standalone `minio` catalog entry, so the chart deploys a bundled MinIO instance. The comment in values acknowledges this as temporary: "until standalone catalog entries exist".
+**Evidence**:
+- `catalog/values/langfuse.yaml` lines 43–52: `s3.deploy: true`, bucket `langfuse`, with static root password
+- `catalog/` directory contains no `minio.yaml` — MinIO is not a shared catalog service
+- Static `rootPassword: changeme` comment says "prevents ArgoCD sync loops" — this is a deliberate workaround for ArgoCD reconciling secrets
+- MinIO at minimum uses ~128–256 MiB memory; with upload activity it peaks higher
+**Cross-domain flag**: yes — other apps (temporal workflow history snapshots, future model artifact storage) would benefit from shared S3-compatible storage
+**Investigation direction**: Add a standalone `minio` catalog entry (`tier: 1-data`, after `cnpg-operator`). Langfuse can then point its `s3.*` values at the shared MinIO. Evaluate MinIO Operator vs standalone MinIO chart. Confirm Langfuse Helm chart supports `s3.endpoint` override pointing to an external service.
+
+---
+
+## Finding 3: Majority of Apps Have No Tier or dependsOn — Ordering Relies Entirely on ArgoCD Retry
+
+**Severity**: High
+**Domain**: AppWorkloads
+**Affected app**: alloy, external-secrets, guardrails-ai, langfuse, litellm-proxy, loki, nemo-guardrails, ollama, opa, presidio, qdrant, tempo, text-embeddings-inference, unstructured
+**Root cause hypothesis**: The `root-catalog.yaml` ApplicationSet uses a `RollingSync` strategy with three tiers (`0-operators`, `1-data`, `2-services`). Only apps with a `tier` label participate in ordered rollout. Apps without `tier` are applied in an unordered batch. Apps without `dependsOn` have no ArgoCD sync-wave dependency either. For apps that make runtime TCP connections to postgresql or valkey at boot time (langfuse, litellm-proxy, temporal), a cold-start race is possible.
+**Evidence**:
+- `bootstrap/root-catalog.yaml` lines 8–25: RollingSync with three explicit tier steps
+- `catalog/cnpg-operator.yaml`: `tier: 0-operators` — present
+- `catalog/postgresql.yaml`: `tier: 1-data`, `dependsOn: [cnpg-operator, prometheus-stack]` — present
+- `catalog/langfuse.yaml`: `tier: 2-services`, `dependsOn: [cnpg-operator, postgresql]` — present
+- `catalog/temporal.yaml`: `tier: 2-services`, `dependsOn: [cnpg-operator, postgresql]` — present
+- `catalog/valkey.yaml`: **no tier** — valkey will deploy in the unordered batch, potentially after langfuse tries to connect to it
+- `catalog/litellm-proxy.yaml`: **no tier, no dependsOn** — litellm-proxy has an env var pointing to Langfuse (`LANGFUSE_HOST`) but no declared dependency
+- `catalog/alloy.yaml`: **no tier, no dependsOn** — alloy hardcodes `loki.observability.svc.cluster.local` and `tempo.observability.svc.cluster.local`; if those aren't up yet, alloy config reload will fail silently
+- `catalog/loki.yaml`, `catalog/tempo.yaml`: **no tier, no dependsOn** — they are alloy's runtime targets
+**Cross-domain flag**: no
+**Investigation direction**: Add `tier: 1-data` to `valkey.yaml`. Add `tier: 2-services` and `dependsOn: [valkey]` to `langfuse.yaml` (valkey is already a runtime dep, just not declared). Add `tier: 2-services` and `dependsOn: [langfuse, ollama]` to `litellm-proxy.yaml`. Group loki/tempo into `tier: 1-data` or `tier: 2-services` and add alloy's `dependsOn: [loki, tempo]`.
+
+---
+
+## Finding 4: Temporal Has No dependsOn for valkey / Missing Visibility Store Awareness
+
+**Severity**: Medium
+**Domain**: AppWorkloads
+**Affected app**: temporal
+**Root cause hypothesis**: Temporal uses PostgreSQL for both its default persistence store and its visibility store. The catalog entry correctly depends on `cnpg-operator` and `postgresql`. However, Temporal's Helm chart (`go.temporal.io/helm-charts`) can optionally use Elasticsearch for advanced visibility; it defaults to SQL visibility, which is correctly wired here. The concern is that `temporal` has no `tier` label, so it may deploy before `postgresql` has finished initializing its `temporal` and `temporal_visibility` databases via `postInitSQL`.
+**Evidence**:
+- `catalog/temporal.yaml` lines 9–12: `tier: 2-services`, `dependsOn: [cnpg-operator, postgresql]` — tier IS present
+- `catalog/values/temporal.yaml` lines 43–55: hardcoded `temporal` role and password matching `postgresql.yaml` postInitSQL
+- `catalog/values/temporal.yaml` line 35: `schema.setup.enabled: true` — Temporal will attempt DDL migration at startup; if PostgreSQL hasn't finished the `postInitSQL` grants yet, the migration job will fail
+- `catalog/values/temporal.yaml` lines 25–28: `postgresql.enabled: false`, `cassandra.enabled: false` — correctly disables bundled DBs
+**Cross-domain flag**: no
+**Investigation direction**: The `dependsOn` is present and correct. The risk is the postInitSQL timing window. Add an ArgoCD sync-wave annotation or a Kubernetes initContainer in a custom patch to wait for the `temporal` role to exist before the schema setup job runs. Alternatively, document that the `temporal` ArgoCD app may need one manual retry after fresh cluster creation.
+
+---
+
+## Finding 5: litellm-proxy Has No Declared Dependencies Despite Hard Runtime Coupling
+
+**Severity**: Medium
+**Domain**: AppWorkloads
+**Affected app**: litellm-proxy
+**Root cause hypothesis**: The litellm-proxy values file hardcodes `LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY` as env vars, and the `proxy_config.model_list` points to `ollama.models.svc.cluster.local`. At startup litellm-proxy will attempt to reach both Langfuse and Ollama. Neither is in a `dependsOn` list, and there is no `tier` label.
+**Evidence**:
+- `catalog/litellm-proxy.yaml`: no `tier`, no `dependsOn`
+- `catalog/values/litellm-proxy.yaml` lines 37–39: `LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`
+- `catalog/values/litellm-proxy.yaml` lines 22–24: `ollama/llama3.2:1b` via `http://ollama.models.svc.cluster.local:11434`
+- LiteLLM proxy performs a health-check ping to configured backends on startup and will log errors (but does not crash) if they are unreachable — however, the Langfuse callback integration requires Langfuse to be reachable for trace submission
+**Cross-domain flag**: no
+**Investigation direction**: Add `tier: 2-services` and `dependsOn: [langfuse, ollama]` to `catalog/litellm-proxy.yaml`. Also consider adding a `litellm` database to postgresql's `postInitSQL` (litellm-proxy optionally persists spend/key data to PostgreSQL; the current config does not wire this but could benefit from it).
+
+---
+
+## Finding 6: alloy Has No Declared Dependencies on loki and tempo
+
+**Severity**: Medium
+**Domain**: AppWorkloads
+**Affected app**: alloy
+**Root cause hypothesis**: Alloy's config (embedded in values) hardcodes two endpoint URLs: `loki.observability.svc.cluster.local:3100` and `tempo.observability.svc.cluster.local:4317`. If alloy starts before loki or tempo, log/trace shipping will fail until those services become available. Alloy does retry, but log loss during the startup window is possible.
+**Evidence**:
+- `catalog/values/alloy.yaml` lines 40–43: `loki.write.default` endpoint
+- `catalog/values/alloy.yaml` lines 60–65: `otelcol.exporter.otlp.tempo` endpoint
+- `catalog/alloy.yaml`: no `tier`, no `dependsOn`
+- `catalog/loki.yaml`: no `tier`, no `dependsOn`
+- `catalog/tempo.yaml`: no `tier`, no `dependsOn`
+**Cross-domain flag**: no
+**Investigation direction**: Add `tier: 1-data` (or `tier: 2-services`) to `loki.yaml` and `tempo.yaml`, then add `dependsOn: [loki, tempo]` to `alloy.yaml`. Both loki and tempo are pure-filesystem deployments with no upstream dependencies of their own, so placing them in `tier: 1-data` is appropriate.
+
+---
+
+## Finding 7: Ollama CPU-Only Memory Limit May Be Insufficient for llama3.2:1b on Constrained Nodes
+
+**Severity**: Medium
+**Domain**: AppWorkloads
+**Affected app**: ollama
+**Root cause hypothesis**: The values file sets a 4 GiB memory limit and pulls `llama3.2:1b` on startup. llama3.2:1b in GGUF Q4_K_M quantisation requires approximately 800 MiB of RAM for the model weights. The 4 GiB limit is reasonable headroom, but the 1 GiB *request* means the scheduler may place ollama on a node where only 1 GiB is actually free — the model will then OOM-kill during inference.
+**Evidence**:
+- `catalog/values/ollama.yaml` lines 11–17: `requests.memory: 1Gi`, `limits.memory: 4Gi`
+- `catalog/values/ollama.yaml` lines 7–9: pulls `llama3.2:1b` at startup
+- On a single-node k3d cluster the scheduler always places on the one node, so the gap between request and limit is less dangerous but still causes misleading capacity reporting
+- llama3.2:1b peak RSS during inference (CPU): ~2–2.5 GiB. The 4 GiB limit is adequate; the 1 GiB request is misleading.
+**Cross-domain flag**: no
+**Investigation direction**: Raise `requests.memory` to at least `2Gi` to match realistic working set. Consider documenting GPU values override (already commented out in the file). For models larger than 3B params, note that the 4 GiB limit must also be raised.
+
+---
+
+## Finding 8: text-embeddings-inference CPU-Only Throughput Is Very Low; Memory Request Understated
+
+**Severity**: Medium
+**Domain**: AppWorkloads
+**Affected app**: text-embeddings-inference
+**Root cause hypothesis**: `BAAI/bge-small-en-v1.5` in CPU mode loads approximately 130 MB of model weights. The 512 MiB memory request is adequate for the model itself, but the HuggingFace TEI server also loads tokeniser libraries (~200 MB) and allocates batch buffers. On CPU, throughput is roughly 10–50 sentences/second depending on batch size. This is functionally usable for low-QPS RAG pipelines but will become a bottleneck if more than one agent submits concurrent embedding requests.
+**Evidence**:
+- `catalog/values/text-embeddings-inference.yaml`: `model: "BAAI/bge-small-en-v1.5"`, `requests.memory: 512Mi`, `limits.memory: 2Gi`
+- HuggingFace TEI image does not have a CPU-only tag for this chart version (`0.1.0`); the default image may attempt to load CUDA libs and fall back gracefully, adding startup latency
+**Cross-domain flag**: no
+**Investigation direction**: Verify that `targetRevision: 0.1.0` of the HuggingFace helm chart supports a `cpu` runtime flag or explicit image tag override for CPU-only inference. Consider bumping to a later chart version that exposes `runtime: cpu` as a value. For higher throughput, evaluate switching to a smaller ONNX-quantized model.
+
+---
+
+## Finding 9: Loki Uses Filesystem Backend — Will Lose Logs on Pod Restart Without Verified PVC
+
+**Severity**: Medium
+**Domain**: AppWorkloads
+**Affected app**: loki
+**Root cause hypothesis**: Loki is deployed in `SingleBinary` mode with `storage.type: filesystem`. The values file enables persistence (`persistence.enabled: true`, `size: 10Gi`) and explicitly disables MinIO (`minio.enabled: false`). This is appropriate for homelab. However, the single-binary image and its filesystem storage mean that if the PVC is lost (e.g., cluster recreated with `k3d cluster delete`), all log history is gone. There is no S3 fallback path configured.
+**Evidence**:
+- `catalog/values/loki.yaml` lines 9–10: `storage.type: filesystem`
+- `catalog/values/loki.yaml` lines 31–33: `persistence.enabled: true`, `size: 10Gi`
+- `catalog/values/loki.yaml` lines 43–44: `minio.enabled: false`
+- The Loki chart `6.55.0` defaults to S3/MinIO in distributed mode; the explicit `minio.enabled: false` is correct and intentional for single-binary
+**Cross-domain flag**: yes — if a shared MinIO catalog entry is added (see Finding 2), loki could optionally be migrated to object storage backend for durability across cluster rebuilds
+**Investigation direction**: This is acceptable for homelab. Document that log history is ephemeral and tied to PVC lifecycle. If durability is required, wire loki to MinIO once the shared MinIO catalog entry exists.
+
+---
+
+## Finding 10: guardrails-ai Memory Limit Is Likely Insufficient for Rule Validation with NLP Models
+
+**Severity**: Medium
+**Domain**: AppWorkloads
+**Affected app**: guardrails-ai
+**Root cause hypothesis**: The Guardrails AI API server (`guardrails-ai/guardrails-api` chart `0.1.0`) is a Python FastAPI application. On startup it loads whatever validators are installed. The 512 MiB limit is adequate for the base server with simple regex-based validators but will be exceeded if spaCy or transformers-based validators are loaded (each NLP model adds 200–500 MiB).
+**Evidence**:
+- `catalog/values/guardrails-ai.yaml`: `requests.memory: 256Mi`, `limits.memory: 512Mi`
+- Guardrails AI's `guardrails-api` Docker image bundles the server but not validators; validators are installed at runtime via `GUARDRAILS_TOKEN` env + hub pull, or baked into a custom image
+- Python process baseline RSS ~100–150 MiB; any spaCy model adds ~200–400 MiB
+**Cross-domain flag**: no
+**Investigation direction**: If only schema/regex validators are used, current limits are fine. If NLP-backed validators (e.g., `toxic-language`, `detect-pii`) are needed, raise limit to at least `1Gi` or `2Gi`. Clarify which validators are expected to be loaded at runtime and document in the values file.
+
+---
+
+## Finding 11: nemo-guardrails Memory Limit Understated for LLM-Backed Rails
+
+**Severity**: Medium
+**Domain**: AppWorkloads
+**Affected app**: nemo-guardrails
+**Root cause hypothesis**: NeMo Guardrails is a Python server that invokes an LLM to evaluate safety rules. The 1 GiB memory limit covers only the server process; any actual LLM inference happens via an external endpoint (Ollama or OpenAI API). The limit is fine if NeMo is configured as a pure proxy (forwarding to Ollama). However, if the NeMo Guardrails image bundles a local model or loads sentence-transformers for semantic similarity checks, 1 GiB will be insufficient.
+**Evidence**:
+- `catalog/values/nemo-guardrails.yaml`: `requests.memory: 512Mi`, `limits.memory: 1Gi`
+- NeMo Guardrails `0.1.0` chart does not appear to bundle a local model — it expects an LLM endpoint configuration
+- No `llm.endpoint` or `openai.*` wiring is present in the values file — the app will fail to apply any LLM-backed rail without additional configuration
+**Cross-domain flag**: yes — nemo-guardrails has an implicit runtime dependency on litellm-proxy or ollama (no endpoint configured in values)
+**Investigation direction**: Add LLM endpoint configuration to `catalog/values/nemo-guardrails.yaml` pointing to litellm-proxy (`http://litellm-proxy.gateway.svc.cluster.local:4000`). Add `dependsOn: [litellm-proxy]` to `catalog/nemo-guardrails.yaml`. Verify that `nemo-guardrails/nemo-guardrails` chart `0.1.0` is an official NVIDIA chart and not a community placeholder — the chart repo `https://nvidia.github.io/NeMo-Guardrails` should be verified.
+
+---
+
+## Finding 12: presidio Analyzer Baseline Memory Is Understated for spaCy en_core_web_lg
+
+**Severity**: Medium
+**Domain**: AppWorkloads
+**Affected app**: presidio
+**Root cause hypothesis**: Microsoft Presidio's analyzer component loads a spaCy NLP model at startup (default: `en_core_web_lg`). This model requires ~750 MiB of RAM. The current values set a 512 MiB limit for the analyzer, which will cause an OOM kill before the model finishes loading.
+**Evidence**:
+- `catalog/values/presidio.yaml` analyzer: `requests.memory: 256Mi`, `limits.memory: 512Mi`
+- Microsoft Presidio Docker image (`mcr.microsoft.com/presidio-analyzer`) bundles `en_core_web_lg` by default
+- spaCy `en_core_web_lg` loaded RSS: ~700–800 MiB; `en_core_web_sm` is ~50 MiB
+**Cross-domain flag**: no
+**Investigation direction**: Raise `analyzer.resources.limits.memory` to at least `1Gi` (or `1.5Gi` to be safe). Alternatively, confirm whether the chart version `0.1.0` allows configuring a smaller spaCy model (`en_core_web_sm`) via a Helm value — if so, `sm` would fit within 512 MiB. The anonymizer (128Mi request / 256Mi limit) is fine as it is purely rule-based.
+
+---
+
+## Finding 13: postgresql ResourceQuota max_connections May Be Exceeded Under Full Profile
+
+**Severity**: Medium
+**Domain**: AppWorkloads
+**Affected app**: postgresql
+**Root cause hypothesis**: The shared PostgreSQL cluster sets `max_connections: 200`. In the `agent-full` profile, multiple apps open connection pools: langfuse (default pool ~10–20), temporal (default pool ~20–50), litellm-proxy (optional, if wired to PG), plus any agent workloads that connect directly. Under full concurrency, total connections can approach or exceed 200, causing new connection attempts to fail.
+**Evidence**:
+- `catalog/values/postgresql.yaml` lines 51–53: `max_connections: "200"`, `shared_buffers: "64MB"`
+- `catalog/values/temporal.yaml`: wires to `temporal` and `temporal_visibility` databases — Temporal server uses a default pool of 20 connections per DB = 40 total minimum
+- `catalog/values/langfuse.yaml`: wires to `langfuse` database — langfuse default pool is 10
+- Total static minimum: ~50–60 connections; with agent workloads and spikes, 200 is reachable
+- `shared_buffers: 64MB` is below PostgreSQL's recommended minimum of 25% of RAM; with 512 MiB limit, this should be at least 128MB
+**Cross-domain flag**: no
+**Investigation direction**: Consider adding PgBouncer as a connection pooler (can be deployed as a sidecar or separate catalog entry). Raise `shared_buffers` to `128MB`. Alternatively, raise `max_connections` to 400 and increase `resources.limits.memory` to `1Gi` to accommodate the larger shared memory allocation.
+
+---
+
+## Finding 14: prometheus-stack Has No Declared dependsOn for postgresql Monitoring Integration
+
+**Severity**: Low
+**Domain**: AppWorkloads
+**Affected app**: prometheus-stack
+**Root cause hypothesis**: The `postgresql.yaml` catalog entry declares `dependsOn: [cnpg-operator, prometheus-stack]` because it creates a `PodMonitor` CRD resource that requires prometheus-stack's CRDs. This is correct. However, `prometheus-stack.yaml` itself has `tier: 0-operators` but no explicit `dependsOn` — meaning ArgoCD deploys it in the first tier wave, which is correct. The risk is the reverse: if someone disables prometheus-stack but leaves postgresql enabled, the `podMonitor.enabled: true` in postgresql values will fail to create a PodMonitor because the CRD is gone. This is an operational rather than deployment-time concern.
+**Evidence**:
+- `catalog/postgresql.yaml` lines 9–12: `tier: 1-data`, `dependsOn: [cnpg-operator, prometheus-stack]`
+- `catalog/values/postgresql.yaml` lines 28–30: `monitoring.enabled: true`, `podMonitor.enabled: true`
+- `catalog/prometheus-stack.yaml`: `tier: 0-operators` — correct tier, no dependsOn needed
+**Cross-domain flag**: no
+**Investigation direction**: Document that postgresql monitoring requires prometheus-stack. Optionally add a conditional in postgresql values: if prometheus-stack is not enabled, set `monitoring.enabled: false`. Currently the `dependsOn` prevents this scenario during initial deploy but does not protect against runtime removal of prometheus-stack.
+
+---
+
+## Finding 15: opa Has No dependsOn but Runtime Integration Requires external-secrets for Policy Secrets
+
+**Severity**: Low
+**Domain**: AppWorkloads
+**Affected app**: opa
+**Root cause hypothesis**: OPA (Open Policy Agent with kube-mgmt) loads policies from Kubernetes ConfigMaps/Secrets. If policies reference secrets managed by external-secrets, OPA requires external-secrets to be running and secrets to be synced before policies can be evaluated. There is no `dependsOn: [external-secrets]` in the opa catalog entry.
+**Evidence**:
+- `catalog/opa.yaml`: no `tier`, no `dependsOn`
+- `catalog/external-secrets.yaml`: `tier: 0-operators`
+- OPA itself does not fail without external-secrets — it starts fine and loads policies from ConfigMaps. The dependency is only relevant if ExternalSecret resources are the policy source.
+**Cross-domain flag**: no
+**Investigation direction**: If policy secrets are managed via external-secrets, add `dependsOn: [external-secrets]` to `opa.yaml`. Otherwise this is informational only. Consider adding `tier: 1-data` to opa to ensure it syncs after operators.
+
+---
+
+## Finding 16: qdrant Has No dependsOn but Profiles Imply It Must Start Before Agent Workloads
+
+**Severity**: Low
+**Domain**: AppWorkloads
+**Affected app**: qdrant
+**Root cause hypothesis**: The agent NetworkPolicy template in `sikifanso-agent-template` hardcodes an egress allowlist entry to `rag` namespace port 6333. This means agents are already designed to use qdrant. However, qdrant has no `tier` or `dependsOn` in the catalog, so it may deploy in an unordered wave. Since qdrant is a pure stateful store with no upstream dependencies, the only risk is agents trying to connect before qdrant's PVC is bound and the server is ready.
+**Evidence**:
+- `catalog/qdrant.yaml`: no `tier`, no `dependsOn`
+- `sikifanso-agent-template/values.yaml` lines 22–25: qdrant allowlist entry hardcoded at `rag:6333`
+- `profile.go` lines 53–54: rag profile includes qdrant
+**Cross-domain flag**: no
+**Investigation direction**: Add `tier: 1-data` to `qdrant.yaml` to ensure it deploys in the data tier before service-tier agents start connecting. No `dependsOn` needed as qdrant has no upstream service dependencies.
+
+---
+
+## Finding 17: Agent Sandbox ResourceQuota Conflates Requests and Limits
+
+**Severity**: Medium
+**Domain**: AppWorkloads
+**Affected app**: N/A (agent-template)
+**Root cause hypothesis**: The agent ResourceQuota template sets `requests.cpu`, `requests.memory`, `limits.cpu`, and `limits.memory` all to the same value (`agent.cpu` and `agent.memory`). This forces every container in the agent namespace to set requests == limits (otherwise the quota is exceeded). This is a valid conservative strategy but prevents burstable QoS for agents — every agent pod is forced into `Guaranteed` QoS class, which is unnecessarily restrictive for orchestration agents that have variable CPU usage.
+**Evidence**:
+- `sikifanso-agent-template/templates/resourcequota.yaml` lines 10–13: `requests.cpu`, `limits.cpu`, `requests.memory`, `limits.memory` all set to identical values
+- Default values: `cpu: "500m"`, `memory: "512Mi"` — these are quota totals for the entire namespace, not per-pod limits
+- A minimal orchestration agent (ReAct loop calling litellm-proxy) needs ~100–200m CPU at burst and ~256 MiB; the 500m/512Mi quota covers one agent process but leaves no headroom for auxiliary containers (sidecar, init containers)
+- A heavy agent (local Ollama-backed inference) would need at least 2000m CPU and 4Gi memory, requiring custom quota override at agent creation time
+**Cross-domain flag**: no
+**Investigation direction**: Split the ResourceQuota into separate request and limit buckets. For example, `requests.cpu: 500m`, `limits.cpu: 2000m` allows burst. Alternatively, document that `agent.cpu` sets the request ceiling and advise users to pass `--cpu 2` for inference-heavy agents. Add two named presets in the template `ci/test-values.yaml`: `minimal` (500m/512Mi) and `inference` (2000m/8Gi).
+
+---
+
+## Finding 18: agent-minimal Profile Missing valkey Dependency
+
+**Severity**: Low
+**Domain**: AppWorkloads
+**Affected app**: profile: agent-minimal
+**Root cause hypothesis**: The `agent-minimal` profile (`profile.go` line 22–25) enables `[litellm-proxy, langfuse, cnpg-operator, postgresql]`. Langfuse's values file wires to valkey (`redis.host: valkey.storage.svc.cluster.local`) but valkey is not in the agent-minimal app list. When the profile is applied, langfuse will deploy and fail its Redis connection on startup.
+**Evidence**:
+- `internal/profile/profile.go` lines 22–25: `agent-minimal` apps: `[litellm-proxy, langfuse, cnpg-operator, postgresql]`
+- `catalog/values/langfuse.yaml` lines 29–34: `redis.deploy: false`, `redis.host: valkey.storage.svc.cluster.local` — requires valkey to be running
+- `catalog/langfuse.yaml` lines 10–12: `dependsOn: [cnpg-operator, postgresql]` — valkey not listed
+**Cross-domain flag**: no
+**Investigation direction**: Add `valkey` to the `agent-minimal` profile apps list. Also add `dependsOn: [valkey]` to `catalog/langfuse.yaml` to make the dependency explicit in the ArgoCD ApplicationSet ordering.
+
+---
+
+## Finding 19: Temporal schema.setup Job May Conflict with Multiple Restarts on Fresh Cluster
+
+**Severity**: Low
+**Domain**: AppWorkloads
+**Affected app**: temporal
+**Root cause hypothesis**: The Temporal Helm chart's `schema.setup.enabled: true` runs a Kubernetes Job to apply DDL migrations. If Temporal is deployed before PostgreSQL's `postInitSQL` completes (creating the `temporal` role and databases), the Job fails. ArgoCD's retry (limit: 3, backoff: 10s) may exhaust retries before PostgreSQL is ready on a slow node, leaving the cluster in a degraded state that requires manual intervention.
+**Evidence**:
+- `catalog/values/temporal.yaml` line 35: `schema.setup.enabled: true`
+- `catalog/values/postgresql.yaml` lines 44–49: `postInitSQL` creates `temporal` role and databases — this runs after the PostgreSQL cluster is `Ready` but timing relative to ArgoCD sync is not guaranteed
+- `catalog/temporal.yaml` lines 9–12: `tier: 2-services`, `dependsOn: [cnpg-operator, postgresql]` — tier is correct but postInitSQL completion is not a Kubernetes readiness signal
+- ArgoCD retry: `limit: 3`, `backoff.duration: 10s`, `backoff.maxDuration: 3m` — the 3-minute window may be insufficient if the single-node cluster is under memory pressure during bootstrap
+**Cross-domain flag**: no
+**Investigation direction**: Add an init container to the temporal schema setup Job (via Helm values or a kustomize patch) that uses `psql -c '\du'` to verify the `temporal` role exists before proceeding. Alternatively, increase ArgoCD retry limit to 5 and `maxDuration` to 10m for the temporal application specifically, using an ArgoCD Application override in the ApplicationSet template.
+
+---
+
+## Appendix: Resource Summary Table
+
+| App | Req CPU | Req Memory | Limit CPU | Limit Memory | Notes |
+|-----|---------|------------|-----------|--------------|-------|
+| alloy | 50m | 64Mi | 200m | 256Mi | DaemonSet — per node |
+| cnpg-operator | (not set in values) | — | — | — | Operator; chart defaults apply |
+| external-secrets | 100m total | 128Mi total | 500m total | 512Mi total | 3 components (main+webhook+cert) |
+| guardrails-ai | 100m | 256Mi | 500m | 512Mi | May need 1Gi for NLP validators |
+| langfuse | 100m | 256Mi | 500m | 1Gi | Plus bundled ClickHouse + MinIO overhead |
+| litellm-proxy | 100m | 256Mi | 500m | 512Mi | |
+| loki | 50m | 128Mi | 200m | 512Mi | SingleBinary mode |
+| nemo-guardrails | 200m | 512Mi | 500m | 1Gi | Needs LLM endpoint configured |
+| ollama | 500m | 1Gi | 2000m | 4Gi | req.memory should be 2Gi |
+| opa | 100m total | 128Mi total | 400m total | 512Mi total | 2 containers (opa+mgmt) |
+| postgresql | 100m | 256Mi | 500m | 512Mi | shared_buffers should be 128MB |
+| presidio | 150m | 384Mi | 700m | 768Mi | analyzer limit must be >=1Gi |
+| prometheus-stack | ~870m | ~788Mi | ~950m | ~2.8Gi | Sum across 5 components |
+| qdrant | 100m | 256Mi | 500m | 1Gi | |
+| temporal | 150m | 384Mi | 700m | 1.25Gi | server + web |
+| tempo | 50m | 128Mi | 200m | 512Mi | |
+| text-embeddings-inference | 200m | 512Mi | 1000m | 2Gi | CPU-only; low throughput |
+| unstructured | 200m | 512Mi | 1000m | 2Gi | |
+| valkey | 50m | 64Mi | 500m | 256Mi | |
+
+**Approximate total (all enabled, agent-full profile)**: ~3.9 CPU cores requested, ~6.5 GiB memory requested; ~11 CPU cores limit, ~22 GiB memory limit. A single-node k3d host should have at least 8 GiB RAM available to the cluster (16 GiB recommended) to avoid OOM pressure under the agent-full profile.

--- a/docs/superpowers/research/findings-argocd.md
+++ b/docs/superpowers/research/findings-argocd.md
@@ -1,0 +1,199 @@
+# ArgoCD Integration: Code Review Findings
+
+## Executive Summary
+
+The sikifanso ArgoCD integration has one confirmed production defect: the CLI exits with a failure on `Synced+Degraded` even when that state is a normal transient startup condition (CRD establishment, PVC binding, image pull back-off), causing false-negative results that recover on their own. The catalog ApplicationSet deliberately omits `automated.selfHeal`/`prune`, meaning that if the CLI-triggered sync races with the AppSet controller, apps can silently stall in `OutOfSync` without any re-drive. Several lower-severity issues compound this: a single-shot `pollOnce` fallback offers no resilience after a stream drop, the `waitForAppear` polling starts immediately before the AppSet controller has had time to act, and the `ResourceTree` call used for failure diagnostics pulls node-level data that misses the more useful `app.Status.Resources` sync-error messages already in `GetApplication`.
+
+---
+
+## Finding 1: `Synced+Degraded` Is Treated as Final When It Is Often Transient
+
+**Severity**: Critical
+
+**Domain**: ArgoCD
+
+**Affected scenario**: `app enable` with auto-deps (e.g. `sikifanso app enable postgresql` auto-enables `prometheus-stack`)
+
+**Root cause hypothesis**: ArgoCD's health model does not distinguish "app just synced and resources are still initialising" from "app is permanently broken." CRDs always pass through `Degraded` ("CRD is not established") for several seconds before the API server registers them. PVCs are `Progressing` (not `Degraded`) while binding, but the pod that depends on them may itself become `Degraded` if the image pull fails transiently. The exit condition at `orchestrator.go:195` fires as soon as the first `Synced+Degraded` event arrives from the watch stream, which for a freshly-synced Helm chart can happen within seconds of the sync completing — before any resource has had a chance to reach steady state.
+
+**Evidence**:
+- `internal/argocd/grpcsync/orchestrator.go:195` — exits immediately on `Health == "Degraded" && SyncStatus == "Synced" && !req.SkipUnhealthy`, with no minimum observation window or resource-type carve-outs.
+- The observed failure log shows `CRD/prometheusagents.monitoring.coreos.com health=Degraded CRD is not established` — this is the canonical transient CRD state; ArgoCD itself marks it `Degraded` for 5–30 s while the API server processes it.
+- `internal/argocd/grpcsync/orchestrator.go:183-189` — the `Result` passed to `updateFn` before the early-exit does not record a timestamp or observation count, so there is no way to add a "seen degraded for N seconds" gate without structural changes.
+- The comment at line 152-153 acknowledges the OutOfSync case was already fixed, but the transient `Synced+Degraded` case was not.
+
+**Cross-domain flag**: No
+
+**Investigation direction**: Introduce a minimum-observation window (e.g. require `Synced+Degraded` to persist for at least 30 s with no intervening `Healthy` events) before declaring failure. Alternatively, whitelist specific resource kinds (CRD, PVC, Pod while its image is being pulled) by inspecting `r.Resources` and only exiting early when the degraded resources are not in a known-transient set. The ArgoCD canonical approach is to consult `app.Status.OperationState.Phase` — if it is `Running` or `Succeeded` and health is `Degraded`, the app is still converging; only `Failed` + `Degraded` is a hard failure.
+
+---
+
+## Finding 2: Catalog ApplicationSet Has No `automated` SyncPolicy — Silent Stall Window
+
+**Severity**: Critical
+
+**Domain**: ArgoCD
+
+**Affected scenario**: `app enable` / `app disable` for any catalog entry
+
+**Root cause hypothesis**: `root-catalog.yaml` defines no `automated` block in its Application template. This means the Application CR created by the AppSet controller has no auto-sync; the only driver is the manual `SyncApplication` call in `waitForAppear` (`orchestrator.go:241`). If that call arrives while ArgoCD is still processing the previous reconcile cycle, or if the sync request is rejected (e.g. another operation is already in flight), the app will stay `OutOfSync` indefinitely — there is no background self-heal to recover it. The `root-app.yaml` and `root-agents.yaml` AppSets correctly set `automated.selfHeal: true` / `prune: true`, making this an inconsistency rather than an intentional choice.
+
+**Evidence**:
+- `sikifanso-homelab-bootstrap/bootstrap/root-catalog.yaml:72-83` — `syncPolicy` block contains only `syncOptions` and `retry`; no `automated` key.
+- `sikifanso-homelab-bootstrap/bootstrap/root-app.yaml:37-40` and `root-agents.yaml:37-40` — both set `automated.selfHeal: true` / `prune: true`.
+- `internal/argocd/grpcsync/orchestrator.go:241` — `SyncApplication` is the sole sync trigger for catalog apps after they appear; log message "sync trigger after appear failed (may already be syncing)" is swallowed at Debug level.
+
+**Cross-domain flag**: No
+
+**Investigation direction**: Add `automated.selfHeal: true` / `prune: true` to the catalog ApplicationSet template, consistent with `root-app` and `root-agents`. The manual `SyncApplication` call in `waitForAppear` can remain as an accelerator to avoid the 3-minute reconcile interval, but it should no longer be the sole mechanism. If the absence of `automated` is intentional (e.g. to prevent background churn in a dev cluster), document it and add a retry loop around the `SyncApplication` call with exponential back-off instead of a single fire-and-forget.
+
+---
+
+## Finding 3: `pollOnce` as Stream Fallback Is Insufficient
+
+**Severity**: High
+
+**Domain**: ArgoCD
+
+**Affected scenario**: Any `watchSingleApp` call where the gRPC stream drops mid-watch
+
+**Root cause hypothesis**: When the gRPC watch stream closes unexpectedly (`eventCh` channel is closed without a `Deleted` event), `watchSingleApp` calls `pollOnce` exactly once and then returns. A single `GetApplication` snapshot may catch the app in any transient intermediate state (e.g. `OutOfSync/Progressing` mid-sync) and record it as the final result, causing a spurious timeout or false healthy/unhealthy report. In a local k3d cluster, the gRPC stream is particularly fragile: there is no load balancer keep-alive, the ArgoCD server pod may restart during cluster bootstrap, and the stream has no client-side heartbeat timeout configured (no `keepalive` or `WaitForReady` options visible in `grpcclient/client.go`).
+
+**Evidence**:
+- `internal/argocd/grpcsync/orchestrator.go:167-170` — `case event, ok := <-eventCh:` with `if !ok { o.pollOnce(...); return }`.
+- `internal/argocd/grpcclient/applications.go:134-136` — `stream.Recv()` error causes the goroutine to return and close the channel; any `recvErr` — including transient network errors — is silent and indistinguishable from a clean stream close.
+- `internal/argocd/grpcclient/client.go:44-85` — `apiclient.ClientOptions` sets no gRPC `DialOptions`, `keepalive.ClientParameters`, or `WaitForReady`.
+- `waitForDisappear` at `orchestrator.go:274-278` also falls back to `pollUntilGone` (which polls in a loop), so it is more resilient than `watchSingleApp`'s single-shot fallback — the asymmetry is inconsistent.
+
+**Cross-domain flag**: No
+
+**Investigation direction**: Replace `pollOnce` with a `pollUntilTerminal` loop (similar to `pollUntilGone`) that keeps polling at `DefaultPollInterval` until the app reaches `Synced+Healthy`, `Degraded`, or ctx timeout. Additionally, consider reopening the watch stream after a transient close (exponential back-off, up to the context deadline) before falling back to polling.
+
+---
+
+## Finding 4: `waitForAppear` First Poll Fires After 5 s, But AppSet Controller May Need Longer
+
+**Severity**: High
+
+**Domain**: ArgoCD
+
+**Affected scenario**: `app enable` — any catalog or custom app
+
+**Root cause hypothesis**: `waitForAppear` starts its ticker immediately and polls every 5 s. However, after `Trigger()` patches the annotation, the AppSet controller must: (1) detect the annotation, (2) re-evaluate the git generator (reads the local hostPath), (3) render the template, (4) create the Application CR. Under normal load this is fast (< 5 s), but during cluster bootstrap when the AppSet controller pod itself may be restarting or under high reconcile queue pressure, the Application CR can take 10–30 s to appear. More critically, `Trigger()` returns immediately after the Kubernetes PATCH call completes — there is no confirmation that the controller has acted on it. The annotation is removed by the controller after reconciliation, but `waitForAppear` never checks whether the annotation was removed as a signal that reconciliation ran.
+
+**Evidence**:
+- `internal/argocd/appsetreconcile/reconcile.go:45-56` — `Trigger` patches annotation and returns; no watch/poll to confirm annotation removal.
+- `internal/argocd/grpcsync/orchestrator.go:214-247` — `waitForAppear` loops on `GetApplication` returning `NotFound`; if the Application exists from a previous run it will pass through immediately and call `SyncApplication` before the AppSet controller has re-rendered it with updated values.
+- `internal/argocd/grpcsync/orchestrator.go:43-46` — `ReconcileFn` (annotation patch) error is only logged as `Warn` and execution continues to `watchApps`; this means `waitForAppear` will block for the full timeout if the patch itself failed silently.
+
+**Cross-domain flag**: No
+
+**Investigation direction**: After `Trigger()`, poll the ApplicationSet CR to wait for the annotation to be removed (confirming the controller acted on it) before starting `waitForAppear`. Alternatively, watch the ApplicationSet CR with a field selector and use `resourceVersion` to confirm a new generation was processed. The annotation removal is documented ArgoCD behaviour for `argocd.argoproj.io/application-set-refresh`.
+
+---
+
+## Finding 5: `SyncApplication` Called After `waitForAppear` With No Operation-State Guard
+
+**Severity**: High
+
+**Domain**: ArgoCD
+
+**Affected scenario**: `app enable` where AppSet has `automated.selfHeal: true` (root, agents AppSets)
+
+**Root cause hypothesis**: `waitForAppear` calls `SyncApplication` as soon as `GetApplication` returns a non-NotFound result (`orchestrator.go:241`). For `root` and `agents` ApplicationSets, the Application is created with `automated.selfHeal: true` / `prune: true`, meaning ArgoCD's controller may have already started an automatic sync. Sending a manual `SyncApplication` while ArgoCD's internal operation is `Running` causes ArgoCD to return a gRPC error ("another operation is already in progress"), which is currently swallowed at Debug level. If the auto-sync finishes before the watch stream is established, the initial state event may arrive showing `Synced+Healthy`, which is correct — but if it arrives showing `OutOfSync/Progressing` (the sync is running), the watcher will keep waiting. The real risk is the opposite: the manual sync request may interrupt a carefully-ordered sync (e.g. CRD before workload), causing resource-ordering failures.
+
+**Evidence**:
+- `internal/argocd/grpcsync/orchestrator.go:241-243` — `SyncApplication` is called unconditionally; the error is `Debug`-logged with message "may already be syncing".
+- `internal/argocd/grpcclient/applications.go:92-107` — `SyncApplication` wraps `client.Sync`; no check for in-flight operations.
+- `sikifanso-homelab-bootstrap/bootstrap/root-app.yaml:37-40` and `root-agents.yaml:37-40` — `automated.selfHeal: true / prune: true`; these apps will auto-sync; the manual trigger is redundant and potentially disruptive.
+- `internal/argocd/grpcclient/applications.go:98-100` — `SyncOptions` only exposes `Prune`; no `DryRun`, `Force`, or `RetryStrategy` to handle the "already syncing" case.
+
+**Cross-domain flag**: No
+
+**Investigation direction**: Before calling `SyncApplication`, call `GetApplication` and inspect `app.Status.OperationState.Phase`. If it is `Running`, skip the manual trigger and proceed directly to `watchSingleApp`. For the `catalog` AppSet (no `automated`), the manual sync is necessary; for `root` and `agents`, it should be conditional.
+
+---
+
+## Finding 6: ResourceTree Used for Failure Diagnostics Misses Sync Error Messages
+
+**Severity**: Medium
+
+**Domain**: ArgoCD
+
+**Affected scenario**: Any failed sync — error detail shown under the `✗` app in terminal output
+
+**Root cause hypothesis**: When `watchSingleApp` detects `Synced+Degraded`, it calls `ResourceTree` (`orchestrator.go:197`) to populate `r.Resources` for display. `ResourceTree` returns `tree.Nodes` (the full resource graph from the ArgoCD cache), which has node-level health and message fields. However, `app.Status.Resources` (returned by `GetApplication` and already mapped in `toResourceStatuses`) contains the per-resource `SyncStatus` alongside the health, which is more actionable for diagnosing sync failures (e.g. "hook failed", "resource already exists"). Additionally, `ResourceTree.Nodes` do not include the `SyncStatus` field at all — only health. The displayed error messages under failing resources may therefore be incomplete or misleading.
+
+**Evidence**:
+- `internal/argocd/grpcclient/applications.go:154-181` — `ResourceTree` maps `tree.Nodes` to `ResourceStatus`; `node.Health` is present but `node` has no `Status` (sync status) field.
+- `internal/argocd/grpcclient/applications.go:71-89` — `toResourceStatuses` maps `app.Status.Resources` which includes both `r.Status` (sync status) and `r.Health`.
+- `internal/argocd/grpcclient/types.go:40-48` — `ResourceStatus` has both `Status` (sync) and `Health` fields, but the `ResourceTree` path leaves `Status` empty.
+- `cmd/sikifanso/middleware.go:172-181` — `printSyncResults` prints `res.Health` and `res.Message` but not `res.Status`; unhealthy-but-synced resources would be silent.
+
+**Cross-domain flag**: No
+
+**Investigation direction**: Replace the `ResourceTree` call in the `Degraded` exit path with an additional `GetApplication` call (which is already available via `o.client.GetApplication`) and use `detail.Resources` (which has both sync status and health). The `ResourceTree` call is more expensive (fetches the full graph) and less informative for the common sync-failure diagnostic case. Only fall back to `ResourceTree` for live-state diffs.
+
+---
+
+## Finding 7: All Apps Watched Concurrently, Ignoring Catalog `RollingSync` Tier Ordering
+
+**Severity**: Medium
+
+**Domain**: ArgoCD
+
+**Affected scenario**: `app enable` with multiple apps across different tiers (e.g. tier-0 operator + tier-2 service)
+
+**Root cause hypothesis**: `watchApps` (`orchestrator.go:82`) launches a goroutine per app concurrently with `sync.WaitGroup`. The catalog ApplicationSet is configured with `strategy.type: RollingSync` with three tiers (`0-operators`, `1-data`, `2-services`). ArgoCD's RollingSync will not start syncing tier-1 until all tier-0 apps are `Healthy`. But the CLI watches all apps concurrently and will report tier-1/2 apps as timing out (still `OutOfSync/Unknown`) even though they are intentionally held back by ArgoCD. This produces confusing output and potentially an incorrect `ExitTimeout` code when the tier sequencing simply hasn't advanced yet.
+
+**Evidence**:
+- `sikifanso-homelab-bootstrap/bootstrap/root-catalog.yaml:7-25` — `strategy.type: RollingSync` with three steps by `tier` label.
+- `internal/argocd/grpcsync/orchestrator.go:96-115` — all apps launched concurrently; no tier-awareness.
+- `internal/argocd/grpcsync/orchestrator.go:127-145` — `ExitTimeout` is the code when `SyncStatus != "Synced" || Health != "Healthy"`; a tier-2 app held at `OutOfSync/Unknown` by RollingSync would produce this code even though ArgoCD is doing the right thing.
+- `internal/catalog/catalog.go:25` — `Entry` has a `Tier` field, so the data is available to the CLI.
+
+**Cross-domain flag**: No
+
+**Investigation direction**: The simplest fix is to not treat `OutOfSync/Unknown` (or `OutOfSync/Missing`) as a hard timeout if the app has a tier label and a lower-tier app is still `Progressing`. A more complete fix is to sequence the `waitForAppear` goroutines by tier: start watching tier-0 first, wait for all tier-0 to be `Synced+Healthy`, then start watching tier-1, and so on. The `catalog.Entry.Tier` field is already populated; it just needs to be threaded into the `Request` type.
+
+---
+
+## Finding 8: gRPC Connection Has No Keep-Alive or Retry Policy
+
+**Severity**: Medium
+
+**Domain**: ArgoCD
+
+**Affected scenario**: Long-running watches (e.g. slow Helm chart with many resources, or cluster under load)
+
+**Root cause hypothesis**: The gRPC client is created with plain `apiclient.ClientOptions` and no additional `DialOptions`. There are no `keepalive.ClientParameters` configured, meaning that idle streams (no events for > 20 s) may be silently dropped by intermediate network components (Docker's internal bridge, CNI, or the OS TCP stack). In a k3d cluster running inside Docker, the bridge network has a connection-tracking timeout that can silently drop idle TCP connections. When this happens, `stream.Recv()` will block until the next event or context cancellation — it will not return an error immediately. This means the fallback to `pollOnce` may not be triggered even when the stream is dead.
+
+**Evidence**:
+- `internal/argocd/grpcclient/client.go:44-85` — no `grpc.WithKeepaliveParams`, no `grpc.WithBlock`, no `grpc.WithReturnConnectionError`.
+- `internal/argocd/grpcclient/applications.go:125-148` — the goroutine calls `stream.Recv()` in a tight loop with only a `ctx.Done()` select guard; a silently-dead stream will block `stream.Recv()` indefinitely without firing the `!ok` branch.
+- The `WatchApplication` channel has a buffer of 16 (`make(chan WatchEvent, 16)`); buffer exhaustion is not detected.
+
+**Cross-domain flag**: No
+
+**Investigation direction**: Add `grpc.WithKeepaliveParams(keepalive.ClientParameters{Time: 20*time.Second, Timeout: 5*time.Second, PermitWithoutStream: true})` to the dial options. Add a separate `time.AfterFunc` deadline inside the watch goroutine: if no event is received within `N` seconds, close the channel explicitly to force the fallback path. This is a known pattern for gRPC watch loops.
+
+---
+
+## Finding 9: `applications.go` Uses `~/.kube/config` Not the Session's Kubeconfig
+
+**Severity**: Low
+
+**Domain**: ArgoCD
+
+**Affected scenario**: Multi-cluster setups where the active kubeconfig context differs from the target cluster
+
+**Root cause hypothesis**: `CreateApplications` in `internal/argocd/applications.go:44` calls `clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)` which reads `~/.kube/config` using the current active context. Every other Kubernetes operation in sikifanso (AppSet reconciler, kube package) uses the cluster-specific kubeconfig from the session. If the user's active context points to a different cluster (e.g. a production cluster or a different k3d cluster), `CreateApplications` will silently create the Application CRDs in the wrong cluster.
+
+**Evidence**:
+- `internal/argocd/applications.go:44-47` — `clientcmd.RecommendedHomeFile` is hardcoded; no cluster name or session path is passed.
+- `internal/argocd/appsetreconcile/reconcile.go:31-38` — correctly accepts `*rest.Config` as a parameter, allowing the caller to provide the right cluster's config.
+- `internal/kube/` — presumably provides `RESTConfigForCluster` (referenced in `middleware.go:95`); `applications.go` does not use it.
+
+**Cross-domain flag**: No
+
+**Investigation direction**: Change `CreateApplications` signature to accept a `*rest.Config` parameter (like `appsetreconcile.NewReconciler` does) and remove the internal `clientcmd.BuildConfigFromFlags` call. All call sites should pass the REST config obtained from `kube.RESTConfigForCluster(sess.ClusterName)`.

--- a/docs/superpowers/research/findings-go.md
+++ b/docs/superpowers/research/findings-go.md
@@ -1,0 +1,139 @@
+# Go Code Review Findings — sikifanso CLI
+
+## Executive Summary
+
+The observed failure (`app enable postgresql` → `sync failed: one or more apps unhealthy`) is reproducible and has a clear root cause: `watchSingleApp` exits on `Synced+Degraded` and classifies that terminal state as `ExitFailure`, but Kubernetes workloads routinely pass through a `Synced+Degraded` window as containers pull images and probes warm up. Five additional findings compound the UX damage — the spinner is racy, error messages discard all actionable context, the post-profile sync in `cluster create` uses `OpSync` (no AppSet reconciliation) against a stale app list, `waitForAppear` has a first-tick latency gap, and the `WatchApplication` goroutine can block `closer.Close()` for the full gRPC stream idle timeout if the context cancels while `Recv` is in flight.
+
+---
+
+## Finding 1: False-Positive Failure on Slow-Starting Apps
+
+**Severity**: Critical  
+**Domain**: Go  
+**Affected scenario**: `app enable` with auto-deps (e.g. `postgresql` pulls in `prometheus-stack`)  
+**Root cause hypothesis**: `watchSingleApp` exits immediately when it sees `SyncStatus == "Synced" && Health == "Degraded"` and hands off that state to `watchApps`, which classifies it as `ExitFailure`. Kubernetes workloads legitimately pass through `Synced+Degraded` while pods are scheduling, pulling images, or failing liveness probes for the first time. ArgoCD reflects this as `Degraded` before pods stabilise. The fix comment in the source (`// FIX: Don't exit on Degraded immediately`) acknowledges this but the implementation still exits unconditionally.  
+**Evidence**:  
+- `grpcsync/orchestrator.go:195–205` — the `Synced+Degraded` branch fetches the resource tree and calls `return`, closing the watch immediately.  
+- `grpcsync/orchestrator.go:134–138` — `watchApps` exit-code logic maps `Health == "Degraded"` to `ExitFailure` with no grace period.  
+- `middleware.go:145` — `ExitFailure` produces `"sync failed: one or more apps unhealthy"` with no retry or advisory.  
+**Cross-domain flag**: no  
+**Investigation direction**: Introduce a configurable `DegradedGracePeriod` (e.g. 60 s default). When the app first enters `Synced+Degraded`, start a timer; if health recovers before the timer fires, continue watching. Only emit `ExitFailure` if the grace period expires while still Degraded. Alternatively, re-open the watch instead of returning — but the grace-period approach is safer because it bounds wait time.
+
+---
+
+## Finding 2: cluster create Post-Profile Sync Uses Wrong Operation and Stale App List
+
+**Severity**: High  
+**Domain**: Go  
+**Affected scenario**: `cluster create --profile agent-dev` (or any profile)  
+**Root cause hypothesis**: After `profile.Apply` commits catalog YAML, `cluster_create.go` calls `client.ListApplications` and passes the result straight into `orch.SyncAndWait` with `OpSync` (the zero-value default). `OpSync` calls `SyncApplication` on each app; it does not trigger AppSet reconciliation. The newly-enabled catalog apps exist only as YAML files in the gitops repo at this point — the ArgoCD ApplicationSet controller has not yet reconciled them into Application CRs. `ListApplications` will therefore either return an empty list (no apps created yet) or return only the root ApplicationSets themselves, missing every newly-enabled catalog app. When the list is empty the sync is silently skipped (`if len(names) > 0`). When it is non-empty but stale the sync targets wrong or already-healthy apps and still exits cleanly, giving a false impression that the profile was deployed.  
+**Evidence**:  
+- `cluster_create.go:115–129` — `ListApplications` → `names` → `SyncAndWait` with no `Operation` field set (defaults to `OpSync`), no `ReconcileFn`, no `OnProgress`.  
+- `grpcsync/types.go:19` — `OpSync OperationType = iota` (value 0, the zero value).  
+- `grpcsync/orchestrator.go:57–64` — `OpSync` path calls `SyncApplication` directly; no AppSet reconcile.  
+- `profile/profile.go:110–176` — `Apply` commits files and returns; it never triggers ArgoCD.  
+**Cross-domain flag**: no  
+**Investigation direction**: Replace the `ListApplications`+`OpSync` pattern with `OpEnable` using the profile app names directly and supply a `ReconcileFn` that triggers the `catalog` ApplicationSet (identical to what `syncAfterMutation` does in `middleware.go:111–121`). This mirrors the path already used by `app enable`.
+
+---
+
+## Finding 3: Spinner Suffix Is a Data Race Under Concurrent Watches
+
+**Severity**: High  
+**Domain**: Go  
+**Affected scenario**: `app enable` with multiple apps syncing concurrently  
+**Root cause hypothesis**: `watchApps` spawns one goroutine per app (`orchestrator.go:96–115`). Each goroutine calls `req.OnProgress`, which directly assigns `s.Suffix` (`middleware.go:115–119`). The `spinner` library does not protect `Suffix` with a mutex in its public API — the background spinner goroutine reads `s.Suffix` on every tick while the watch goroutines write it. This is a data race. Additionally, the suffix is overwritten by whichever goroutine fires last; earlier progress from other apps is lost.  
+**Evidence**:  
+- `middleware.go:103` — `s := spinner.New(...)` (single spinner, single `Suffix` field).  
+- `middleware.go:114–120` — `OnProgress` closure writes `s.Suffix` directly.  
+- `orchestrator.go:96–115` — multiple goroutines all invoke `req.OnProgress` concurrently.  
+- `go test -race` on any `app enable` with ≥2 apps will surface this as a race on `s.Suffix`.  
+**Cross-domain flag**: no  
+**Investigation direction**: (a) Replace the single spinner with a multi-line progress renderer that maintains a `map[string]string` of per-app status, protected by a `sync.Mutex`, and re-renders all lines on each `OnProgress` call. Or (b) replace `OnProgress` with a buffered status channel read by a single renderer goroutine, eliminating the mutex entirely. The `charmbracelet/lipgloss` or a simple ANSI-escape approach works well here.
+
+---
+
+## Finding 4: Error Messages Discard All Available Context
+
+**Severity**: High  
+**Domain**: Go  
+**Affected scenario**: Any sync failure or timeout  
+**Root cause hypothesis**: `syncAfterMutation` receives the full `[]grpcsync.Result` slice including per-resource health details, but the error messages it returns to the user contain only static strings. The user is told `"sync failed: one or more apps unhealthy"` or `"sync timed out: apps may still be reconciling"` with no indication of which app failed, what its health/sync state was, or which resources are degraded. `printSyncResults` writes this detail to stderr before the error is returned, but if the terminal clears (e.g. in CI) or the user piped output, none of it survives.  
+**Evidence**:  
+- `middleware.go:136–151` — error construction uses only static strings; `results` is ignored.  
+- `middleware.go:156–183` — `printSyncResults` has the data but it is called before the error (line 138), which is fine in interactive mode but lossy in CI.  
+- `grpcsync/types.go:39–46` — `Result` carries `App`, `SyncStatus`, `Health`, `Message`, `Resources` — all discarded by the error message.  
+**Cross-domain flag**: no  
+**Investigation direction**: Build the error string from the result slice: iterate results, collect those with non-success health, and append `app=NAME sync=X health=Y` pairs. For timeout, list which apps had not yet reached `Synced+Healthy`. This gives the user — and CI logs — enough context to act without reading a separate stderr block.
+
+---
+
+## Finding 5: waitForAppear First-Poll Delay Is Always DefaultPollInterval
+
+**Severity**: Medium  
+**Domain**: Go  
+**Affected scenario**: `app enable` with `OpEnable`, fast-reconciling ApplicationSets  
+**Root cause hypothesis**: `waitForAppear` creates a ticker and then immediately enters a `select` that waits for either `ctx.Done` or `ticker.C` (`orchestrator.go:219–237`). The tick fires after `DefaultPollInterval` (5 seconds), meaning the function always waits at least 5 seconds before checking whether the app exists — even when the ApplicationSet controller has already reconciled and the Application CR appeared in < 1 second. For fast clusters this adds unnecessary latency to every `app enable`.  
+**Evidence**:  
+- `grpcsync/types.go:12` — `DefaultPollInterval = 5 * time.Second`.  
+- `orchestrator.go:215–235` — ticker created, select blocks immediately on `ticker.C`; no initial check before the first tick.  
+**Cross-domain flag**: no  
+**Investigation direction**: Add an immediate `GetApplication` call before entering the poll loop — the same pattern used by `waitForDisappear` at lines 252–259. If the app already exists, skip straight to `watchSingleApp`. This turns the common fast path from ≥5 s to ≤1 s.
+
+---
+
+## Finding 6: WatchApplication Goroutine Can Block on Recv After Context Cancel
+
+**Severity**: Medium  
+**Domain**: Go  
+**Affected scenario**: Timeout or user interrupt (Ctrl-C) during any watch  
+**Root cause hypothesis**: The goroutine in `WatchApplication` uses a non-blocking ctx check (`select { case <-ctx.Done(): return; default: }`) before calling `stream.Recv()` (`applications.go:129–135`). `stream.Recv()` is a blocking call. If the context cancels after the `default` branch is taken, the goroutine blocks inside `Recv` until the gRPC server closes the stream — which for a long-running watch may be many seconds or until the idle timeout fires. During this window `closer.Close()` (the gRPC sub-connection) is not called, and the goroutine leaks until `Recv` unblocks. The outer `ctx` cancellation should cause `Recv` to return with an error because the context is attached to the gRPC stream, but this relies on gRPC propagating the cancellation through `stream.Context()`, which only works if the stream was opened with the same context (it is, at line 118). So in practice the race window is small — but the pattern is still fragile.  
+**Evidence**:  
+- `applications.go:129–147` — non-blocking ctx poll before `Recv`; no `select` on `Recv` result.  
+- `applications.go:125–148` — goroutine defers `closer.Close()`; it does not close until `Recv` returns.  
+- `client.go:108` — `Client.Close()` is a no-op, so there is no outer close racing with the goroutine's `closer.Close()` (the race question from the prompt is therefore not an issue as currently coded, but only because `Close()` is a no-op).  
+**Cross-domain flag**: no  
+**Investigation direction**: The current implementation is mostly safe because gRPC does propagate context cancellation through the stream. The main residual risk is the non-blocking ctx poll pattern; replace the `select { default }` pattern with a pure context-driven approach: rely on `stream.Recv()` returning a non-nil error when the context is cancelled, and remove the pre-check loop entirely. Also document that `Client.Close()` is a no-op so callers do not assume it cancels active streams.
+
+---
+
+## Finding 7: ExitCode Default Branch Conflates Progressing and Unknown
+
+**Severity**: Medium  
+**Domain**: Go  
+**Affected scenario**: Any sync that times out while an app is still `Progressing` or `Unknown`  
+**Root cause hypothesis**: The `watchApps` exit-code logic (`orchestrator.go:127–143`) has three cases: explicit success (`Synced+Healthy` or `Deleted`), explicit failure (`Degraded` or `Missing`), and a `default` branch that maps everything else to `ExitTimeout`. The `default` branch silently covers `Progressing`, `Unknown`, `Suspended`, and any future ArgoCD health state strings. An app that is `Unknown` because ArgoCD lost contact with the cluster is indistinguishable from an app that is legitimately `Progressing`. Both produce `ExitTimeout` and the same error message. `Unknown` typically warrants a louder failure signal.  
+**Evidence**:  
+- `orchestrator.go:134–143` — `default` case maps to `ExitTimeout`.  
+- `middleware.go:149–150` — both `ExitTimeout` cases produce `"sync timed out: apps may still be reconciling"`.  
+**Cross-domain flag**: no  
+**Investigation direction**: Add an explicit `Unknown` branch that maps to `ExitFailure` (or a new `ExitUnknown` code). Separate the error message for true timeout (`Progressing`) from connectivity/unknown errors. For `Suspended` (app intentionally paused by an operator), consider warning the user rather than failing.
+
+---
+
+## Finding 8: watchSingleApp pollOnce Fallback Provides a Single Stale Snapshot
+
+**Severity**: Medium  
+**Domain**: Go  
+**Affected scenario**: gRPC stream failure mid-sync (network hiccup, ArgoCD pod restart)  
+**Root cause hypothesis**: When `WatchApplication` returns an error or the channel closes mid-sync, `watchSingleApp` falls back to `pollOnce` (`orchestrator.go:157–169`). `pollOnce` calls `GetApplication` once, calls `updateFn` with whatever it receives, and returns. If `GetApplication` also fails (e.g. ArgoCD is restarting), `updateFn` is called with a zeroed `Result` (no health, no sync status). The zeroed result's `SyncStatus == ""` and `Health == ""` fall into the `default` branch of `watchApps` exit-code logic, producing `ExitTimeout`. The user gets no indication that the watch failed mid-stream; they just see a timeout with a blank status line.  
+**Evidence**:  
+- `orchestrator.go:154–169` — single `pollOnce` on any stream error; no retry.  
+- `orchestrator.go:320–336` — `pollOnce` calls `updateFn(Result{App: name})` (zeroed) on error.  
+- `orchestrator.go:139–141` — zeroed result: `Health == ""` and `SyncStatus == ""` → `default` → `ExitTimeout`.  
+**Cross-domain flag**: no  
+**Investigation direction**: Replace the single `pollOnce` with `pollUntilGone` (already implemented for `waitForDisappear`) or a bounded `pollWithRetry` that retries `GetApplication` every `DefaultPollInterval` until success or `ctx` cancels. Log a warning to the user that the watch stream failed and polling has taken over, so they understand the degraded mode.
+
+---
+
+## Finding 9: syncAfterMutation ReconcileFn Is Passed Through Request But Only Called at Sync Start
+
+**Severity**: Low  
+**Domain**: Go  
+**Affected scenario**: `app enable` with a transient AppSet reconciliation failure  
+**Root cause hypothesis**: `ReconcileFn` is called once at the start of `OpEnable`/`OpDisable` (`orchestrator.go:43–55`). If the patch fails (`reconcile.go:48–52`), `SyncAndWait` logs a warning and continues into `watchApps`, which will then block for the full timeout waiting for apps that will never appear (because the ApplicationSet was never reconciled). There is no retry of the reconciliation.  
+**Evidence**:  
+- `orchestrator.go:43–46` — `ReconcileFn` called once; error is only logged, not returned.  
+- `appsetreconcile/reconcile.go:45–56` — `Trigger` returns an error on any patch failure; the error is silently downgraded to a warning.  
+**Cross-domain flag**: no  
+**Investigation direction**: Surface the `ReconcileFn` error to the caller rather than swallowing it — or at minimum retry once with a brief backoff before giving up. If reconciliation fails, return early with a clear error rather than waiting for the full timeout.

--- a/docs/superpowers/research/findings-homelab.md
+++ b/docs/superpowers/research/findings-homelab.md
@@ -1,0 +1,298 @@
+# Homelab Resource Findings — sikifanso Catalog
+
+**Date**: 2026-04-04
+**Scope**: 19 catalog apps + 5 profiles + agent sandbox template
+**Assumption**: Single-node k3d cluster on a developer laptop, 8-16 GB RAM available for Kubernetes workloads.
+
+---
+
+## Resource Summary Table
+
+| App | Memory Request | Memory Limit | CPU Request | CPU Limit | PVC Size | Replicas | Values File? |
+|-----|---------------|--------------|-------------|-----------|----------|----------|-------------|
+| alloy | 64Mi | 256Mi | 50m | 200m | none | 1 (DaemonSet) | yes |
+| cnpg-operator | upstream default | upstream default | upstream default | upstream default | none | 1 | yes (no resources set) |
+| external-secrets | 64Mi + 32Mi + 32Mi = 128Mi total | 256Mi + 128Mi + 128Mi = 512Mi total | 100m total | 400m total | none | 1+1+1 | yes |
+| guardrails-ai | 256Mi | 512Mi | 100m | 500m | none | 1 | yes |
+| langfuse | 256Mi (app only) | 1Gi (app only) | 100m (app only) | 500m (app only) | none (app) | 1 | yes |
+| langfuse/clickhouse (bundled) | upstream default | upstream default | upstream default | upstream default | upstream default | upstream default | n/a — sub-chart |
+| langfuse/minio (bundled) | upstream default | upstream default | upstream default | upstream default | upstream default | upstream default | n/a — sub-chart |
+| litellm-proxy | 256Mi | 512Mi | 100m | 500m | none | 1 | yes |
+| loki | 128Mi | 512Mi | 50m | 200m | 10Gi | 1 | yes |
+| nemo-guardrails | 512Mi | 1Gi | 200m | 500m | none | 1 | yes |
+| ollama | 1Gi | 4Gi | 500m | 2000m | 20Gi | 1 | yes |
+| opa | 64Mi + 64Mi = 128Mi total | 256Mi + 256Mi = 512Mi total | 100m total | 400m total | none | 1 | yes |
+| postgresql (CNPG) | 256Mi | 512Mi | 100m | 500m | 10Gi | 1 | yes |
+| presidio | 256Mi + 128Mi = 384Mi total | 512Mi + 256Mi = 768Mi total | 150m total | 700m total | none | 2 (1+1) | yes |
+| prometheus-stack | 752Mi total (see note) | 2.9Gi total (see note) | 320m total | ~1000m total | 20Gi (prometheus) + 5Gi (alertmanager) + 2Gi (grafana) = 27Gi | 1 each | yes |
+| qdrant | 256Mi | 1Gi | 100m | 500m | 10Gi | 1 | yes |
+| tempo | 128Mi | 512Mi | 50m | 200m | 10Gi | 1 | yes |
+| temporal | 256Mi + 128Mi = 384Mi total | 1Gi + 256Mi = 1.25Gi total | 150m total | 700m total | none (uses cluster PG) | 1+1 | yes |
+| text-embeddings-inference | 512Mi | 2Gi | 200m | 1000m | none | 1 | yes |
+| unstructured | 512Mi | 2Gi | 200m | 1000m | none | 1 | yes |
+| valkey | 64Mi | 256Mi | 50m | 500m | 2Gi | 1 | yes |
+
+**Notes on prometheus-stack totals**: prometheus 512Mi + grafana 128Mi + operator 64Mi + kube-state-metrics 32Mi + node-exporter 16Mi = 752Mi requests. Limits: prometheus 2Gi + grafana 512Mi + operator 256Mi + ksm 128Mi + node-exporter 64Mi = 2.96Gi.
+
+**agent-sandbox template**: ResourceQuota hard cap per agent namespace — 500m CPU request/limit, 512Mi memory request/limit, 10 pods. These caps apply to whatever workload runs inside each agent namespace and are sensible for a homelab.
+
+---
+
+## Profile Memory Request Totals
+
+### agent-minimal
+Apps: litellm-proxy, langfuse, cnpg-operator, postgresql
+
+| App | Memory Request |
+|-----|---------------|
+| litellm-proxy | 256Mi |
+| langfuse (app) | 256Mi |
+| langfuse/clickhouse (bundled, upstream) | ~500Mi (typical upstream default) |
+| langfuse/minio (bundled, upstream) | ~128Mi (typical upstream default) |
+| cnpg-operator | ~128Mi (upstream default) |
+| postgresql | 256Mi |
+| **Total** | **~1.5Gi** |
+
+Verdict: Fits comfortably in 8Gi. The unknown is ClickHouse.
+
+### agent-dev
+Apps: litellm-proxy, ollama, langfuse, qdrant, cnpg-operator, postgresql, valkey, alloy
+
+| App | Memory Request |
+|-----|---------------|
+| litellm-proxy | 256Mi |
+| ollama | 1Gi |
+| langfuse (app) | 256Mi |
+| langfuse/clickhouse (bundled) | ~500Mi |
+| langfuse/minio (bundled) | ~128Mi |
+| qdrant | 256Mi |
+| cnpg-operator | ~128Mi |
+| postgresql | 256Mi |
+| valkey | 64Mi |
+| alloy | 64Mi |
+| **Total** | **~2.9Gi** |
+
+Verdict: Fits in 8Gi with room to spare. Ollama is the dominant consumer.
+
+### agent-safe
+Apps: litellm-proxy, ollama, langfuse, qdrant, cnpg-operator, postgresql, valkey, guardrails-ai, nemo-guardrails, presidio, opa
+
+| App | Memory Request |
+|-----|---------------|
+| litellm-proxy | 256Mi |
+| ollama | 1Gi |
+| langfuse (app + bundled) | ~884Mi |
+| qdrant | 256Mi |
+| cnpg-operator | ~128Mi |
+| postgresql | 256Mi |
+| valkey | 64Mi |
+| guardrails-ai | 256Mi |
+| nemo-guardrails | 512Mi |
+| presidio (2 pods) | 384Mi |
+| opa | 128Mi |
+| **Total** | **~4.1Gi** |
+
+Verdict: Fits in 8Gi but tight. Multiple inference/NLP services run concurrently.
+
+### rag
+Apps: qdrant, text-embeddings-inference, unstructured, cnpg-operator, postgresql
+
+| App | Memory Request |
+|-----|---------------|
+| qdrant | 256Mi |
+| text-embeddings-inference | 512Mi |
+| unstructured | 512Mi |
+| cnpg-operator | ~128Mi |
+| postgresql | 256Mi |
+| **Total** | **~1.7Gi** |
+
+Verdict: Very comfortable.
+
+### agent-full (all 19 apps)
+
+| App | Memory Request |
+|-----|---------------|
+| alloy | 64Mi |
+| cnpg-operator | ~128Mi |
+| external-secrets | 128Mi |
+| guardrails-ai | 256Mi |
+| langfuse (app + bundled) | ~884Mi |
+| litellm-proxy | 256Mi |
+| loki | 128Mi |
+| nemo-guardrails | 512Mi |
+| ollama | 1Gi |
+| opa | 128Mi |
+| postgresql | 256Mi |
+| presidio | 384Mi |
+| prometheus-stack | 752Mi |
+| qdrant | 256Mi |
+| tempo | 128Mi |
+| temporal | 384Mi |
+| text-embeddings-inference | 512Mi |
+| unstructured | 512Mi |
+| valkey | 64Mi |
+| **Total** | **~6.6Gi** |
+
+Verdict: Exceeds the comfortable 8Gi headroom when combined with OS, k3d overhead, Cilium (~300Mi), ArgoCD (~500Mi), and CoreDNS. Total system pressure is approximately 8-9Gi — on the edge for a 16Gi host and likely causes OOM kills on 8Gi available RAM.
+
+---
+
+## Executive Summary
+
+The individual apps are mostly well-tuned for homelab use — resource requests are conservative and replicas are consistently set to 1. The critical problem is additive: the `agent-full` profile stacks all 19 apps simultaneously, pushing declared memory requests to ~6.6Gi before accounting for Cilium, ArgoCD, CoreDNS, and system overhead, which together consume another 1-2Gi. On a machine with 8Gi available for k3d this will reliably cause OOM evictions under moderate workload. Three specific issues dominate: (1) Langfuse's bundled ClickHouse and MinIO have no resource constraints at all, making their actual consumption opaque and uncontrolled; (2) Temporal ships with multiple internal services (frontend, matching, history, worker) that the values file does not individually constrain, so its actual footprint exceeds the 384Mi declared in the top-level `server` values; (3) the Prometheus retention PVC at 20Gi and the Ollama model PVC at 20Gi bring total PVC allocations to 79Gi, which may exhaust local-path storage on a developer laptop with a modest SSD. The `agent-minimal` and `rag` profiles are genuinely safe for homelab use; `agent-full` is not without intervention.
+
+---
+
+## Finding 1: Langfuse Bundled Sub-Charts Have No Resource Constraints
+
+**Severity**: Critical
+**Domain**: Homelab
+**Affected app**: langfuse
+**Root cause hypothesis**: The langfuse values file only sets resources for the main application container. Two bundled sub-charts (`clickhouse.deploy: true` and `s3.deploy: true`) inherit their upstream defaults with no homelab overrides. ClickHouse is known to allocate 2-4Gi RAM at startup with default settings; MinIO typically requests 256-512Mi. Neither has limits set, so a single app can silently consume most of the cluster's available memory.
+**Evidence**:
+- `/Users/alicanalbayrak/dev/sikifanso/sikifanso-homelab-bootstrap/catalog/values/langfuse.yaml` lines 37-58: `clickhouse.deploy: true` and `s3.deploy: true` with no `resources:` stanza under either sub-chart.
+- Langfuse app resources at lines 53-59: only 256Mi request / 1Gi limit — but this covers only the Next.js frontend, not ClickHouse or MinIO.
+- ClickHouse upstream Helm chart default: 2Gi memory request with no limit.
+**Cross-domain flag**: yes — also a cost/reliability concern if ClickHouse OOMs and corrupts its data directory on the hostPath volume.
+**Investigation direction**: Add `clickhouse.resources` and `s3.resources` overrides to `langfuse.yaml`. For ClickHouse, set `memory: 512Mi` request / `1Gi` limit and tune `clickhouse.settings.max_memory_usage` to match. Evaluate whether a standalone ClickHouse catalog entry (per `project_langfuse_deps.md` memory) would give better visibility and control.
+
+---
+
+## Finding 2: Temporal Helm Chart Deploys Multiple Services — Only Top-Level Resources Are Set
+
+**Severity**: High
+**Domain**: Homelab
+**Affected app**: temporal
+**Root cause hypothesis**: The Temporal Helm chart (v0.73.2) deploys four separate server components — frontend, history, matching, and worker — each as its own Deployment. The values file only sets `server.replicaCount: 1` and `server.resources`, which may apply globally or only to a parent chart wrapper. In practice, each Temporal service pod runs independently and the chart also deploys an `admintools` init Job and a `schema` setup Job. Without per-service resource overrides, actual cluster consumption is likely 4× the declared 256Mi request.
+**Evidence**:
+- `/Users/alicanalbayrak/dev/sikifanso/sikifanso-homelab-bootstrap/catalog/values/temporal.yaml` lines 4-13: single `server.resources` block with no per-service (frontend/history/matching/worker) breakdown.
+- The temporal Helm chart GitHub source (go.temporal.io/helm-charts v0.73.2) defines separate `frontend`, `history`, `matching`, `worker` top-level keys each accepting their own `resources` and `replicaCount`.
+**Cross-domain flag**: no
+**Investigation direction**: Expand the temporal values file to explicitly set `frontend.resources`, `history.resources`, `matching.resources`, and `worker.resources` each to 128Mi request / 512Mi limit. Also set `admintools.resources` to prevent unbounded init containers. Verify which key `server.resources` actually maps to in the chart.
+
+---
+
+## Finding 3: agent-full Profile Exceeds Safe Memory Envelope for 8-16Gi Hosts
+
+**Severity**: High
+**Domain**: Homelab
+**Affected app**: profile: agent-full (all 19 apps)
+**Root cause hypothesis**: The `agent-full` profile enables every catalog app simultaneously. Declared memory requests total ~6.6Gi. Adding Cilium (~300Mi), ArgoCD controller + server + applicationset-controller (~500Mi), CoreDNS (~50Mi), k3d node agents (~100Mi), and OS baseline yields a system-wide pressure of 7.5-9Gi. On a host with 8Gi available for k3d, the Linux OOM killer will evict pods under any load spike. On a 16Gi host it is marginal.
+**Evidence**:
+- Profile definition: `/Users/alicanalbayrak/dev/sikifanso/sikifanso/internal/profile/profile.go` lines 29-37: all 19 apps listed.
+- Memory request sum computed from values files: ~6.6Gi (see Profile Memory Request Totals table above), not including Langfuse sub-charts.
+- Ollama alone requests 1Gi with a 4Gi limit; prometheus-stack requests 752Mi.
+**Cross-domain flag**: no
+**Investigation direction**: Consider making `agent-full` a documentation-only "max configuration" label and recommending `agent-dev` or `agent-safe` as the practical starting profiles. Alternatively, gate `agent-full` with a preflight check in the CLI (`sikifanso cluster create`) that reads available node memory and warns before enabling this profile.
+
+---
+
+## Finding 4: Prometheus PVC Set to 20Gi — Exact Size of Ollama Model PVC
+
+**Severity**: High
+**Domain**: Homelab
+**Affected app**: prometheus-stack
+**Root cause hypothesis**: Prometheus is configured with `retention: 7d` and a 20Gi storage claim. For a single-node homelab cluster scraping perhaps 20-40 pods, 7-day retention consumes far less than 20Gi (typical: 1-3Gi). The 20Gi figure was likely copied from a production template. Combined with Ollama's 20Gi model PVC, Loki's 10Gi, Tempo's 10Gi, PostgreSQL's 10Gi, Qdrant's 10Gi, AlertManager's 5Gi, Grafana's 2Gi, and Valkey's 2Gi, total PVC allocation reaches 89Gi. Local-path provisioner on a developer laptop with a 256-512GB SSD may not comfortably accommodate this alongside Docker images and OS files.
+**Evidence**:
+- `/Users/alicanalbayrak/dev/sikifanso/sikifanso-homelab-bootstrap/catalog/values/prometheus-stack.yaml` line 23-25: `storage: 20Gi`.
+- `/Users/alicanalbayrak/dev/sikifanso/sikifanso-homelab-bootstrap/catalog/values/ollama.yaml` line 25: `size: 20Gi`.
+- Combined PVC footprint: alloy(0) + loki(10Gi) + prometheus(20Gi) + alertmanager(5Gi) + grafana(2Gi) + tempo(10Gi) + postgresql(10Gi) + qdrant(10Gi) + ollama(20Gi) + valkey(2Gi) = **89Gi total**.
+**Cross-domain flag**: no
+**Investigation direction**: Reduce prometheus PVC to 5Gi (sufficient for 7-day homelab retention). Reduce AlertManager PVC to 1Gi (alert state is tiny). Consider reducing Ollama to 10Gi if only small models (llama3.2:1b = ~800MB) are pulled. Total PVC savings available: ~31Gi.
+
+---
+
+## Finding 5: cnpg-operator Has No Resource Requests or Limits
+
+**Severity**: Medium
+**Domain**: Homelab
+**Affected app**: cnpg-operator
+**Root cause hypothesis**: The cnpg-operator values file sets `replicaCount: 1`, `crds.create: true`, and `config.clusterWide: true`, but contains no `resources:` stanza. The CNPG operator is a Go controller-manager and typically uses 50-100Mi at idle, but it has no upper bound set. On a single-node cluster with no resource isolation, an operator bug or a large number of cluster reconciliations could consume unbounded memory.
+**Evidence**:
+- `/Users/alicanalbayrak/dev/sikifanso/sikifanso-homelab-bootstrap/catalog/values/cnpg-operator.yaml`: no `resources:` key present.
+- All other operator-style apps in the catalog (external-secrets, opa) have explicit resources set.
+**Cross-domain flag**: no
+**Investigation direction**: Add a `resources:` block with `requests: {memory: 64Mi, cpu: 50m}` and `limits: {memory: 256Mi, cpu: 200m}`. These match the pattern used for external-secrets and opa operators.
+
+---
+
+## Finding 6: Ollama Memory Limit (4Gi) Is Conservative for CPU-Only Inference
+
+**Severity**: Medium
+**Domain**: Homelab
+**Affected app**: ollama
+**Root cause hypothesis**: Ollama is configured for CPU-only mode with `llama3.2:1b` (quantized model, ~800MB on disk). The 4Gi memory limit is generous for a 1B parameter model but appropriate if users load larger models later. The 1Gi request is realistic. The risk is that operators who add larger models (e.g., llama3.1:8b = ~4.7GB) will silently OOM because the limit is set to 4Gi and the model won't fit. There is no documentation in the values file warning that the limit must be raised before pulling larger models.
+**Evidence**:
+- `/Users/alicanalbayrak/dev/sikifanso/sikifanso-homelab-bootstrap/catalog/values/ollama.yaml` lines 6-17: `models.pull: [llama3.2:1b]`, `limits.memory: 4Gi`.
+- llama3.1:8b Q4 quantization requires ~4.7GB RAM for CPU inference, which exceeds the 4Gi limit.
+**Cross-domain flag**: yes — litellm-proxy references `ollama/llama3.2:1b` explicitly; changing the model requires updating both files.
+**Investigation direction**: Add a comment in the values file listing the memory requirement for common models (1b = ~1Gi, 3b = ~2.5Gi, 8b = ~5Gi). Consider whether the limit should be raised to 6Gi to safely accommodate 7B/8B models, and update the litellm-proxy values accordingly if the model is changed.
+
+---
+
+## Finding 7: Temporal Values File Does Not Disable Cassandra or Elasticsearch Schema Jobs
+
+**Severity**: Medium
+**Domain**: Homelab
+**Affected app**: temporal
+**Root cause hypothesis**: The Temporal Helm chart's default values include schema setup jobs for multiple persistence backends. The values file correctly disables `cassandra.enabled: false` and `mysql.enabled: false`, and sets `schema.setup.enabled: true`. However, the chart may still render Elasticsearch/OpenSearch schema jobs unless explicitly disabled. Temporal v1.x charts default to running additional schema migration jobs that can fail on startup if Elasticsearch is not present, causing CrashLoopBackOff noise.
+**Evidence**:
+- `/Users/alicanalbayrak/dev/sikifanso/sikifanso-homelab-bootstrap/catalog/values/temporal.yaml` lines 29-32: only `cassandra`, `postgresql`, and `mysql` are explicitly disabled. No `elasticsearch.enabled: false` present.
+- The temporal Helm chart (v0.73.2) includes an `elasticsearch` sub-chart enabled by default in some versions.
+**Cross-domain flag**: no
+**Investigation direction**: Add `elasticsearch.enabled: false` to the temporal values file. Also verify `schema.update.enabled: false` is set if schema migrations are handled by `schema.setup` only. Review the chart's `values.yaml` to confirm which sub-charts are enabled by default in v0.73.2.
+
+---
+
+## Finding 8: Prometheus Retention at 7 Days Is Fine, But No Retention Size Guard
+
+**Severity**: Low
+**Domain**: Homelab
+**Affected app**: prometheus-stack
+**Root cause hypothesis**: The values file sets `retention: 7d` but does not set `retentionSize`. Without a size-based retention guard, Prometheus will use the full 20Gi PVC regardless of time-based retention — if ingest rate is high (e.g., many scrape targets at 15s interval), the TSDB can grow to fill the 20Gi before the 7-day window expires, causing silent data loss via head compaction rather than a clear error.
+**Evidence**:
+- `/Users/alicanalbayrak/dev/sikifanso/sikifanso-homelab-bootstrap/catalog/values/prometheus-stack.yaml` lines 18-20: `retention: 7d` with no `retentionSize` key.
+**Cross-domain flag**: no
+**Investigation direction**: Add `retentionSize: "4GB"` under `prometheusSpec` (assumes 5Gi PVC after reducing per Finding 4). This ensures the TSDB never fills the volume. Also consider reducing the scrape interval from the default 1m to 2m for homelab use to reduce ingest pressure.
+
+---
+
+## Finding 9: Agent Sandbox ResourceQuota Sets requests.limit Equal to limits.limit
+
+**Severity**: Low
+**Domain**: Homelab
+**Affected app**: agent sandbox template
+**Root cause hypothesis**: The ResourceQuota template hard-sets `requests.cpu`, `limits.cpu`, `requests.memory`, and `limits.memory` all to the same value (agent.cpu and agent.memory respectively). This means every pod in the agent namespace must specify both requests and limits, and those values must match the quota cap exactly. This prevents pods from using Burstable QoS class (request < limit), forcing them into either Guaranteed (request == limit) or causing scheduling failures if they don't set limits. For experimental agent workloads this is unnecessarily rigid.
+**Evidence**:
+- `/Users/alicanalbayrak/dev/sikifanso/sikifanso-agent-template/templates/resourcequota.yaml` lines 9-14: `limits.cpu` and `requests.cpu` both set to `{{ .Values.agent.cpu }}`.
+- `/Users/alicanalbayrak/dev/sikifanso/sikifanso-agent-template/values.yaml` lines 4-8: `cpu: "500m"`, `memory: "512Mi"` — single value used for both requests and limits quota.
+**Cross-domain flag**: no
+**Investigation direction**: Separate quota values into `agent.cpuRequest` / `agent.cpuLimit` and `agent.memoryRequest` / `agent.memoryLimit`, or set only `limits.cpu` and `limits.memory` in the quota (omitting request-side quota) to allow Burstable pods. This gives agent workloads more flexibility without removing the safety ceiling.
+
+---
+
+## Finding 10: NeMo Guardrails 512Mi Request Is Likely Underestimated
+
+**Severity**: Medium
+**Domain**: Homelab
+**Affected app**: nemo-guardrails
+**Root cause hypothesis**: NeMo Guardrails (NVIDIA) is a Python-based LLM guardrail framework that loads NLP models and a LangChain/LlamaIndex runtime at startup. The 512Mi memory request is likely insufficient for the default configuration, which loads SpaCy models and potentially downloads additional NLTK/transformers data on first run. The 1Gi limit may also be too low if the application loads any local embedding models for semantic similarity checks.
+**Evidence**:
+- `/Users/alicanalbayrak/dev/sikifanso/sikifanso-homelab-bootstrap/catalog/values/nemo-guardrails.yaml` lines 7-11: `requests.memory: 512Mi`, `limits.memory: 1Gi`.
+- NeMo Guardrails documentation notes that the ColangRuntime and LangChain integration layers each require 200-400MB base memory before loading any rails configuration.
+**Cross-domain flag**: yes — nemo-guardrails is paired with guardrails-ai (256Mi request) in both `agent-safe` and `agent-full`; both running simultaneously adds 768Mi+ in requests for guardrail-layer apps alone.
+**Investigation direction**: Run `nemo-guardrails` in isolation and observe actual RSS before setting values. If using the default colang runtime without local LLMs, 768Mi request / 1.5Gi limit is a safer estimate. If semantic similarity checks via a local embedding model are enabled, increase to 1Gi request / 2Gi limit.
+
+---
+
+## Summary of PVC Totals by Profile
+
+| Profile | Total PVC Allocated |
+|---------|-------------------|
+| agent-minimal | 10Gi (postgresql only) |
+| agent-dev | 52Gi (postgresql 10 + ollama 20 + qdrant 10 + loki 10 + valkey 2) |
+| agent-safe | 42Gi (postgresql 10 + ollama 20 + qdrant 10 + valkey 2) |
+| rag | 30Gi (postgresql 10 + qdrant 10 + tempo 10) |
+| agent-full | 89Gi (all apps) |
+
+**Recommendation**: The 89Gi total for `agent-full` should be documented prominently. Users on laptops with limited SSD space should be warned before enabling the full profile.

--- a/docs/superpowers/research/findings-k8s.md
+++ b/docs/superpowers/research/findings-k8s.md
@@ -1,0 +1,310 @@
+# K8s Readiness & Ordering Findings
+
+## Executive Summary
+
+The `sikifanso cluster create` flow installs Cilium and ArgoCD via Helm, then immediately
+creates Application CRDs and applies root ApplicationSets — all on a freshly started
+single-node k3d cluster. The chain has two structural gaps: (1) `waitForDeployments`
+checks only the `Available` condition on three ArgoCD deployments, but `Available=True`
+is set before the ArgoCD admission webhook is accepting requests, so `CreateApplications`
+can race against webhook readiness; (2) the orchestrator's `watchSingleApp` exits as
+soon as `Synced+Degraded` is observed, treating any mid-startup degradation — including
+CRD `Establishing` states, image-pull retries, and unbound PVCs — as a permanent failure.
+Together these two issues produce false-negative errors for apps that would self-heal
+within 2-3 minutes. The root cause is that the readiness model conflates "deployment
+replicas are up" with "the cluster is ready to receive application workloads."
+
+---
+
+## Finding 1: ArgoCD Webhook Not Ready When CreateApplications Is Called
+
+**Severity**: High
+**Domain**: K8s
+**Affected scenario**: `cluster create`
+
+**Root cause hypothesis**: `waitForDeployments` polls `DeploymentAvailable` on
+`argocd-server`, `argocd-repo-server`, and `argocd-applicationset-controller`. The
+`Available` condition is set by the Deployment controller once `minReadySeconds` elapses
+after a pod becomes Ready — but the ArgoCD admission webhook (`argocd-server` exposes it)
+can still be initialising its internal TLS cert and gRPC listener after the pod passes its
+readiness probe. `CreateApplications` is called immediately after `waitForDeployments`
+returns, and the dynamic client `Create` call hits the Kubernetes API server, which routes
+through the ArgoCD mutating/validating webhook. If the webhook is not yet bound, the API
+server returns a transient `connection refused` or `dial timeout` that surfaces as an
+unretried hard error.
+
+**Evidence**:
+- `install.go:70-73`: `waitForDeployments` is the only gate before returning control to the
+  caller. There is no additional buffer or webhook liveness check.
+- `install.go:90-133`: the poll loop checks `deploymentAvailable(dep)` which maps directly
+  to `DeploymentAvailable=True` — nothing more.
+- `cluster.go:172-192`: `argocd.Install` is followed immediately by `argocd.CreateApplications`
+  with no intermediate sleep or readiness probe targeting the webhook endpoint.
+- ArgoCD's webhook is served on port 8080 of `argocd-server`. The readiness probe for
+  `argocd-server` targets `/healthz` on the same port — so the probe passing does not
+  guarantee the Application admission logic is wired up inside the same process.
+
+**Cross-domain flag**: No
+
+**Investigation direction**:
+- Add a post-`waitForDeployments` probe that performs a lightweight no-op API call
+  through the ArgoCD gRPC client (e.g. `GetVersion`) before calling `CreateApplications`.
+- Alternatively, wrap the `Create` call in `CreateApplications` with a retry loop
+  (exponential backoff, 3-5 attempts) that distinguishes transient connection errors from
+  permanent API errors.
+
+---
+
+## Finding 2: `watchSingleApp` Exits Immediately on First `Synced+Degraded` Event
+
+**Severity**: Critical
+**Domain**: K8s
+**Affected scenario**: `app enable` with catalog apps that install CRDs or use PVCs
+
+**Root cause hypothesis**: `watchSingleApp` in `orchestrator.go` has two terminal exit
+conditions: `Synced+Healthy` (success) and `Synced+Degraded` (failure). During the first
+sync of a CRD-heavy Helm chart (e.g. prometheus-stack), ArgoCD completes the `kubectl
+apply` of all manifests, marks sync status as `Synced`, but many resources are still
+initialising — CRDs are `Establishing`, PVCs are `Pending`, pods are pulling images.
+ArgoCD aggregates these into a `Degraded` health status at the Application level. The
+orchestrator sees `Synced+Degraded` and exits immediately, fetching the resource tree and
+surfacing the error to the user — even though the app would reach `Healthy` in 2-3 minutes
+with no intervention.
+
+This is the direct cause of the observed failure: `prometheus-stack` showed
+`Synced+Degraded` with Progressing PVCs and an EOF image pull, and the CLI printed
+"sync failed: one or more apps unhealthy" even though the cluster recovered on its own.
+
+**Evidence**:
+- `orchestrator.go:195-206`: the `Synced+Degraded` branch calls `ResourceTree` and then
+  calls `updateFn(r)` followed by `return`. There is no grace period and no re-observation
+  window.
+- `orchestrator.go:192-194`: `Synced+Healthy` is the only non-error terminal state.
+- The `SkipUnhealthy` field in `Request` (types.go:34) exists but is not set by the
+  `app enable` command path for the prometheus-stack scenario — its semantics are
+  "skip this app entirely", not "keep waiting".
+- The comment block at `orchestrator.go:153` explicitly notes this as a known issue:
+  "FIX: Don't exit on Degraded immediately. Only exit on Degraded if the app is also
+  Synced." — but the fix only guards the `OutOfSync+Degraded` case; it does not introduce
+  a stabilisation window for `Synced+Degraded`.
+
+**Cross-domain flag**: No
+
+**Investigation direction**:
+- Introduce a configurable stabilisation window (e.g. 30-60 seconds) after the first
+  `Synced+Degraded` observation. If the app transitions to `Synced+Healthy` within that
+  window, report success. If it remains Degraded or worsens after the window, report
+  failure. This is the same pattern used by Flux's `Ready` condition with `retryInterval`.
+- Alternatively, classify the Degraded sub-resources: PVCs in `Progressing` and CRDs in
+  `Establishing` are expected transient states during first-apply. Exit early only if
+  the resource-level health is `Degraded` (not `Progressing`).
+
+---
+
+## Finding 3: CRD Establishment Race During First Helm Apply
+
+**Severity**: High
+**Domain**: K8s
+**Affected scenario**: `app enable` with CRD-heavy charts (prometheus-stack, cert-manager, etc.)
+
+**Root cause hypothesis**: When a Helm chart includes CRDs (either in the `crds/` directory
+or as regular templates), Kubernetes applies them via the API server, which then runs the
+CRD validation and schema establishment pipeline asynchronously. The CRD object is created
+and immediately visible, but its `Established` condition starts as `False`. ArgoCD syncs
+the CRD object successfully (it was accepted by the API server), but its health check
+reports `Degraded` because `Established=False`. Any custom resources that reference the
+CRD — e.g. `PrometheusAgent`, `Prometheus` — cannot be created until `Established=True`,
+so ArgoCD may report their status as `Degraded` as well. On a fresh single-node cluster
+there is no spare etcd write bandwidth so CRD establishment can take 10-30 seconds per
+CRD even under light load.
+
+The observed log line `CRD/prometheusagents.monitoring.coreos.com health=Degraded CRD is
+not established` and `CRD/prometheuses.monitoring.coreos.com health=Progressing Status
+conditions not found` are both transient CRD establishment states.
+
+**Evidence**:
+- `orchestrator.go:195-206`: the orchestrator exits on `Synced+Degraded` without checking
+  whether degraded resources are CRDs in the `Establishing` state.
+- ArgoCD's built-in health check for CRD resources checks the `Established` and
+  `NamesAccepted` conditions. Until both are `True`, the CRD health is `Progressing`
+  (conditions not found) or `Degraded` (explicitly `False`).
+
+**Cross-domain flag**: No
+
+**Investigation direction**:
+- Use the `ServerSideApply=true` sync option (already set in `buildApplication`,
+  `applications.go:121`) together with ArgoCD's `Replace=true` for CRDs. This alone does
+  not fix establishment timing but avoids apply conflicts.
+- The correct fix is at the orchestrator layer: do not treat `Progressing` sub-resources
+  as a reason to exit. Only sub-resources with `Degraded` health that are not CRDs or PVCs
+  should trigger early exit.
+- For charts that own CRDs, consider enabling ArgoCD's `CreateNamespace=true` +
+  `SkipDryRunOnMissingResource=true` sync options, which tolerate missing CRDs mid-sync.
+
+---
+
+## Finding 4: PVC Binding Is Legitimately Asynchronous on k3d
+
+**Severity**: Medium
+**Domain**: K8s
+**Affected scenario**: `app enable` with stateful apps (prometheus-stack, Langfuse, ClickHouse)
+
+**Root cause hypothesis**: k3d uses the `local-path-provisioner` (bundled with k3s) as the
+default StorageClass. This provisioner creates the backing directory on the host on first
+pod scheduling, then binds the PVC. On a freshly started cluster the provisioner pod itself
+may still be initialising. PVCs therefore stay in `Pending` → `Bound` for anywhere from
+30 seconds to 3 minutes depending on Docker Desktop I/O latency. ArgoCD reports `Pending`
+PVCs as `Progressing` health, which contributes to the Application's `Degraded` aggregate
+state when combined with any other non-Healthy resource.
+
+**Evidence**:
+- The observed failure shows three PVCs in `Progressing` state:
+  `PVC/alertmanager-...`, `PVC/prometheus-...`, `PVC/prometheus-stack-grafana`.
+- These are `WaitForFirstConsumer` binding mode PVCs — they only bind after a pod is
+  scheduled, which itself requires the image to be pulled.
+- `orchestrator.go:195`: no special handling for PVCs in `Progressing` state.
+
+**Cross-domain flag**: No
+
+**Investigation direction**:
+- PVCs in `Progressing` (not `Degraded`) are not failures. The orchestrator's early-exit
+  logic should distinguish `Progressing` from `Degraded` at the sub-resource level.
+- For the homelab scenario, consider pre-pulling heavy images or using a local registry
+  mirror (k3d supports `--registry-use`) to reduce binding latency cascades.
+
+---
+
+## Finding 5: Image Pull EOF Causes App-Level Degraded
+
+**Severity**: Medium
+**Domain**: K8s
+**Affected scenario**: `app enable` on a slow or flaky network connection
+
+**Root cause hypothesis**: On macOS with Docker Desktop, image pulls go through the Docker
+Desktop VM's network stack, which adds latency and occasional connection resets (manifesting
+as EOF during layer streaming). A single pod with `ImagePullBackOff` or `ErrImagePull`
+causes the Deployment's rollout to stall. ArgoCD's health assessment for Deployments checks
+whether the rollout has progressed; a stalled rollout maps to `Degraded`. Because the
+orchestrator exits immediately on `Synced+Degraded`, a transient EOF that kubelet would
+retry within 30 seconds causes a permanent CLI failure.
+
+**Evidence**:
+- Observed log: `Pod/prometheus-stack-kube-state-metrics-... health=Degraded failed to pull
+  image "registry.k8s.io/kube-state-metrics/...:v2.18.0": EOF`.
+- Kubelet's image pull retry policy is exponential backoff starting at 10 seconds, capped
+  at 5 minutes. The app self-healed after the CLI reported failure, confirming the EOF was
+  transient.
+
+**Cross-domain flag**: No
+
+**Investigation direction**:
+- The same stabilisation window fix described in Finding 2 covers this case.
+- Additionally, consider a local registry mirror or image pre-pull DaemonSet for
+  catalog apps that are known to have large images (kube-state-metrics, Grafana).
+
+---
+
+## Finding 6: No Buffer Between `waitForDeployments` and ArgoCD gRPC Readiness
+
+**Severity**: High
+**Domain**: K8s
+**Affected scenario**: `cluster create` — first `CreateApplications` call after fresh install
+
+**Root cause hypothesis**: `waitForDeployments` in `install.go` checks the Kubernetes
+`Deployment.Available` condition. A pod is `Ready` when its readiness probe passes. For
+`argocd-server`, the readiness probe is an HTTP GET to `/healthz`. However, ArgoCD's gRPC
+service — used by the `grpcclient` — starts on the same pod and listens on port 8080. The
+gRPC server is initialised after the HTTP handlers and requires loading the ArgoCD
+application cache, establishing the in-cluster Kubernetes informer watches, and registering
+the webhook handlers. These steps complete asynchronously after the pod's readiness probe
+passes. The `syncAfterMutation` middleware (referenced in CLAUDE.md) and `CreateApplications`
+use the gRPC client immediately after `Install` returns, and can hit the gRPC server before
+it has finished initialising.
+
+**Evidence**:
+- `install.go:70-73`: control returns to `cluster.go:172` as soon as `waitForDeployments`
+  passes, with no gRPC-level health check.
+- `cluster.go:177-192`: `CreateApplications` uses the dynamic Kubernetes client (not gRPC),
+  but the API server routes through the ArgoCD webhook for `argoproj.io` resources.
+- `grpcclient/client.go` (not read in detail but referenced): the gRPC client connects at
+  call time; a connection refused at that moment yields an opaque error returned from
+  `SyncApplication` or `GetApplication`.
+
+**Cross-domain flag**: No
+
+**Investigation direction**:
+- After `waitForDeployments`, add a gRPC ping probe: call `argocd.GetVersion()` (or
+  `ServerVersion`) in a retry loop (e.g. up to 30 seconds, 2-second intervals) before
+  proceeding to `CreateApplications`. This is the same technique the ArgoCD CLI itself
+  uses in its `--grpc-web-root-path` healthcheck path.
+- Alternatively, wrap `CreateApplications` in a retry loop since it already handles
+  `AlreadyExists` idempotently.
+
+---
+
+## Finding 7: All Root ApplicationSets Start Concurrently Without Sequencing
+
+**Severity**: Medium
+**Domain**: K8s
+**Affected scenario**: `cluster create` on a constrained single-node k3d host
+
+**Root cause hypothesis**: After `CreateApplications` registers the Cilium and ArgoCD
+Applications, `gitops.ApplyRootApp` applies all three root ApplicationSets
+(`root-app.yaml`, `root-catalog.yaml`, `root-agents.yaml`). ArgoCD begins reconciling all
+of them simultaneously. On a single Docker Desktop VM (typically 2-4 CPUs, 4-8 GB RAM),
+this means Cilium (CNI), ArgoCD (large chart), and any catalog entries already marked
+`enabled: true` all compete for image pull bandwidth, container runtime scheduling, etcd
+write throughput, and CPU during the same 2-3 minute window. This amplifies all the
+transient failures described in Findings 3-5.
+
+**Evidence**:
+- `cluster.go:195-197`: `gitops.ApplyRootApp` is called with no sequencing against the
+  ArgoCD and Cilium Application syncs.
+- CLAUDE.md describes the triple-track model: root-app, root-catalog, root-agents all
+  start from a single `ApplyRootApp` call.
+- The observed failure had three PVCs and a pod all in transient states simultaneously,
+  consistent with parallel startup contention.
+
+**Cross-domain flag**: No
+
+**Investigation direction**:
+- Enforce startup ordering: wait for the Cilium Application to reach `Synced+Healthy`
+  before applying root-catalog and root-agents ApplicationSets.
+- After Cilium is healthy, wait for ArgoCD's own Application to reach `Synced+Healthy`
+  before enabling catalog entries, since ArgoCD's CRDs and webhooks may be reinstalled by
+  its own Application sync.
+- This requires the orchestrator to support a `WaitForApps` primitive that blocks until
+  a named set of Applications are healthy before releasing the next phase.
+
+---
+
+## Finding 8: `kubeconfig` Resolved from Default File Path in Every API Call
+
+**Severity**: Low
+**Domain**: K8s
+**Affected scenario**: All — any multi-cluster user
+
+**Root cause hypothesis**: Both `waitForDeployments` (`install.go:91`) and
+`CreateApplications` (`applications.go:44`) call
+`clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)`, which reads
+`~/.kube/config` and uses whatever context is currently active. sikifanso calls
+`k3dclient.KubeconfigGetWrite` with `UpdateCurrentContext: true` (`cluster.go:149-153`)
+immediately before, so the context switch is likely correct for a single-cluster workflow.
+However, in a multi-cluster scenario (two sikifanso clusters side-by-side), if the user
+switches context between cluster creation steps, or if another process changes the context,
+the wrong cluster receives the ArgoCD install. There is also no error if the current context
+does not match the cluster being created.
+
+**Evidence**:
+- `install.go:91-98` and `applications.go:44-52`: both independently resolve kubeconfig
+  from the recommended home file with no cluster-name validation.
+- `cluster.go:148-154`: kubeconfig is written and context updated, but the kubeconfig
+  object is discarded rather than being threaded through to subsequent API calls.
+
+**Cross-domain flag**: No
+
+**Investigation direction**:
+- Pass the `*rest.Config` (or a `clientcmd.ClientConfig` bound to the specific cluster name)
+  from `KubeconfigGetWrite` through `Install` and `CreateApplications` as a parameter,
+  rather than re-reading the global kubeconfig. This eliminates the TOCTOU race between
+  context-switch and API calls.

--- a/docs/superpowers/specs/2026-04-04-argocd-deployment-research-design.md
+++ b/docs/superpowers/specs/2026-04-04-argocd-deployment-research-design.md
@@ -1,0 +1,143 @@
+# ArgoCD Deployment Research Design
+**Date**: 2026-04-04
+**Status**: Approved
+
+## Goal
+
+Produce a structured problem report that identifies reliability and UX issues in the
+sikifanso ArgoCD deployment pipeline (CLI machinery) and resource-sizing issues across
+all homelab catalog apps (bootstrap repo). The report feeds follow-up investigation
+sessions that propose targeted fixes.
+
+## Scope
+
+Two parallel tracks:
+
+1. **CLI/ArgoCD machinery** — sync orchestrator, health interpretation, progress
+   reporting, error messaging, gRPC watch lifecycle
+2. **Homelab catalog apps** — Helm values for all catalog entries, resource sizing for
+   a single-node k3d cluster, shared-services audit (apps that bundle infra they
+   could borrow from the lab)
+
+## Methodology: Parallel Domain-Expert Panel → Synthesis
+
+Five specialist agents run in parallel. Each produces a structured findings doc. A
+synthesis agent then reads all five, deduplicates, resolves cross-domain findings, and
+writes the final report.
+
+### Agent 1 — ArgoCD Specialist
+
+**Investigates**:
+- `sikifanso/internal/argocd/grpcsync/`
+- `sikifanso/internal/argocd/grpcclient/`
+- `sikifanso/internal/argocd/appsetreconcile/`
+
+**Key questions**:
+- Is `Synced+Degraded` the right exit condition, or does ArgoCD's health model have
+  transient Degraded states that don't mean failure?
+- Is the gRPC watch stream fallback to a single `pollOnce` snapshot adequate when the
+  stream drops mid-sync?
+- Is triggering AppSet reconciliation via annotation patch reliable? Are there race
+  conditions between the annotation being cleared and the CLI starting `waitForAppear`?
+- Does `selfHeal: false` on the Application CRD cause unexpected sync behaviour?
+- Is `waitForAppear` polling at 5s intervals the right mechanism?
+
+### Agent 2 — Kubernetes Resource & Health Specialist
+
+**Investigates**:
+- `sikifanso/internal/argocd/install.go`
+- `sikifanso/internal/cluster/cluster.go`
+- The `app enable postgresql` log output
+
+**Key questions**:
+- CRD `Degraded` during startup — real failure or startup ordering noise?
+- Does `waitForDeployments` check the right condition before `CreateApplications`?
+- Single-node k3d: scheduling and resource-contention effects of parallel startup?
+- Are there CRD → operator → CR ordering requirements the code doesn't enforce?
+
+### Agent 3 — Go Code Reviewer
+
+**Investigates**:
+- `sikifanso/cmd/sikifanso/cluster_create.go`
+- `sikifanso/cmd/sikifanso/app_cmd.go`
+- `sikifanso/cmd/sikifanso/middleware.go`
+- `sikifanso/internal/argocd/grpcsync/orchestrator.go`
+
+**Key questions**:
+- Are error messages actionable?
+- Is the post-profile sync using the right operation type?
+- Is the multi-app spinner progress display correct?
+- Is the gRPC client Close() lifecycle correct?
+- Is there missing distinction between transient and permanent errors?
+
+### Agent 4 — Homelab / Resource-Constraints Expert
+
+**Investigates**:
+- `sikifanso-homelab-bootstrap/catalog/*.yaml`
+- `sikifanso-homelab-bootstrap/catalog/values/*.yaml`
+
+**Key questions**:
+- Which apps have production-sized defaults that exceed homelab capacity?
+- What is the total resource envelope per profile on 8–16 GB available RAM?
+- Which apps have documented minimum-viable Helm values?
+- Are there apps that fundamentally cannot fit a homelab node?
+
+### Agent 5 — K8s App Workloads Specialist
+
+**Investigates**:
+- All catalog entries in `sikifanso-homelab-bootstrap/catalog/`
+- `sikifanso-agent-template/`
+
+**Key questions**:
+- **Shared-services audit**: which apps bundle PostgreSQL, Redis, MinIO/S3, ClickHouse,
+  or other infra? For each: is the lab's shared instance a viable replacement?
+- Are there apps where the shared service cannot be a safe drop-in?
+- What is the total resource envelope per profile when all co-deployed apps run?
+- Are agent sandbox ResourceQuota values appropriate for AI workloads?
+
+### Synthesis Agent
+
+Reads all five findings docs and:
+1. Deduplicates findings that share a root cause
+2. Resolves cross-domain flags — writing combined insights
+3. Ranks by user impact
+4. Generates investigation tasks
+
+## Finding Output Format
+
+```
+## Finding [N]: [Short Title]
+**Severity**: Critical | High | Medium | Low
+**Domain**: ArgoCD | K8s | Go | Homelab | AppWorkloads
+**Affected scenario**: e.g. "app enable with auto-deps"
+**Root cause hypothesis**: what we believe is causing this
+**Evidence**: specific file:line references, config excerpts, log snippets
+**Cross-domain flag**: yes/no
+**Investigation direction**: what a follow-up session should examine
+```
+
+## Final Report Location
+
+`docs/superpowers/reports/2026-04-04-argocd-deployment-research-report.md`
+
+## Permissions
+
+Read/Glob/Grep auto-approved for:
+- `/Users/alicanalbayrak/dev/sikifanso/**`
+- `/Users/alicanalbayrak/dev/sikifanso-homelab-bootstrap/**`
+- `/Users/alicanalbayrak/dev/sikifanso-agent-template/**`
+
+Configured in `.claude/settings.local.json`.
+
+## Known Context
+
+The `app enable postgresql` execution produced this observed failure:
+- `prometheus-stack` reported `sync=Synced health=Degraded` while resources were still
+  `Progressing` (PVCs, Pods, CRDs)
+- One image pull failed with EOF — transient network error
+- The CLI exited with "sync failed: one or more apps unhealthy" even though the app
+  recovered later
+- All auto-enabled dependencies deployed simultaneously with no ordering
+
+The Langfuse deployment failed due to ClickHouse requesting ~12 GB on a single homelab
+node — a resource-sizing issue in the bootstrap repo values.

--- a/internal/argocd/grpcsync/orchestrator.go
+++ b/internal/argocd/grpcsync/orchestrator.go
@@ -22,8 +22,16 @@ type appClient interface {
 // Orchestrator manages sync-and-watch operations for one or more ArgoCD applications
 // using the gRPC Watch stream for real-time feedback.
 type Orchestrator struct {
-	client appClient
-	log    *zap.Logger
+	client       appClient
+	log          *zap.Logger
+	pollInterval time.Duration // zero → DefaultPollInterval; set in tests for speed
+}
+
+func (o *Orchestrator) pollIntervalOrDefault() time.Duration {
+	if o.pollInterval > 0 {
+		return o.pollInterval
+	}
+	return DefaultPollInterval
 }
 
 // NewOrchestrator creates an Orchestrator backed by the given gRPC client.
@@ -166,12 +174,12 @@ func (o *Orchestrator) watchApps(ctx context.Context, req Request, fn watchFn) (
 //   - Deleted → deleted
 //   - ctx cancelled → caller handles via ExitTimeout
 //
-// On stream error the function falls back to a single pollOnce call.
+// On stream error the function falls back to pollUntilTerminal.
 func (o *Orchestrator) watchSingleApp(ctx context.Context, name string, req Request, updateFn func(Result)) {
 	eventCh, err := o.client.WatchApplication(ctx, name)
 	if err != nil {
 		o.log.Warn("watch failed, falling back to poll", zap.String("app", name), zap.Error(err))
-		o.pollOnce(ctx, name, updateFn)
+		o.pollUntilTerminal(ctx, name, updateFn)
 		return
 	}
 
@@ -224,7 +232,7 @@ func (o *Orchestrator) watchSingleApp(ctx context.Context, name string, req Requ
 
 		case event, ok := <-eventCh:
 			if !ok {
-				o.pollOnce(ctx, name, updateFn)
+				o.pollUntilTerminal(ctx, name, updateFn)
 				return
 			}
 
@@ -277,7 +285,7 @@ func (o *Orchestrator) watchSingleApp(ctx context.Context, name string, req Requ
 
 // waitForAppear polls for the app to exist, then watches for Synced+Healthy.
 func (o *Orchestrator) waitForAppear(ctx context.Context, name string, req Request, updateFn func(Result)) {
-	ticker := time.NewTicker(DefaultPollInterval)
+	ticker := time.NewTicker(o.pollIntervalOrDefault())
 	defer ticker.Stop()
 
 	// Poll until the app exists.
@@ -361,7 +369,7 @@ func (o *Orchestrator) waitForDisappear(ctx context.Context, name string, _ Requ
 
 // pollUntilGone polls GetApplication until the app is not found.
 func (o *Orchestrator) pollUntilGone(ctx context.Context, name string, updateFn func(Result)) {
-	ticker := time.NewTicker(DefaultPollInterval)
+	ticker := time.NewTicker(o.pollIntervalOrDefault())
 	defer ticker.Stop()
 
 	for {
@@ -382,20 +390,50 @@ func (o *Orchestrator) pollUntilGone(ctx context.Context, name string, updateFn 
 	}
 }
 
-// pollOnce performs a single GetApplication call and passes the result to updateFn.
-func (o *Orchestrator) pollOnce(ctx context.Context, name string, updateFn func(Result)) {
-	detail, err := o.client.GetApplication(ctx, name)
-	if err != nil {
-		o.log.Warn("poll failed", zap.String("app", name), zap.Error(err))
-		updateFn(Result{App: name})
-		return
+// pollUntilTerminal polls GetApplication in a loop until the app reaches a
+// terminal state or ctx is cancelled. Used as fallback when the Watch stream
+// fails or closes before the app is done.
+//
+// Terminal states:
+//   - Synced+Healthy → success
+//   - Degraded or Missing → failure
+//   - ctx cancelled → caller handles via ExitTimeout
+//
+// The first poll happens immediately on entry (before the ticker fires) so
+// stream-error fallback is responsive with no initial delay. Subsequent polls
+// wait for the ticker first so a cancelled context never triggers a wasted RPC.
+func (o *Orchestrator) pollUntilTerminal(ctx context.Context, name string, updateFn func(Result)) {
+	ticker := time.NewTicker(o.pollIntervalOrDefault())
+	defer ticker.Stop()
+
+	poll := func() (terminal bool) {
+		detail, err := o.client.GetApplication(ctx, name)
+		if err != nil {
+			o.log.Warn("poll failed", zap.String("app", name), zap.Error(err))
+			return false
+		}
+		updateFn(Result{
+			App:        name,
+			SyncStatus: detail.SyncStatus,
+			Health:     detail.Health,
+			Message:    detail.Message,
+			Resources:  detail.Resources,
+		})
+		return (detail.SyncStatus == "Synced" && detail.Health == "Healthy") ||
+			detail.Health == "Degraded" || detail.Health == "Missing"
 	}
 
-	updateFn(Result{
-		App:        name,
-		SyncStatus: detail.SyncStatus,
-		Health:     detail.Health,
-		Message:    detail.Message,
-		Resources:  detail.Resources,
-	})
+	if poll() {
+		return
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		if poll() {
+			return
+		}
+	}
 }

--- a/internal/argocd/grpcsync/orchestrator.go
+++ b/internal/argocd/grpcsync/orchestrator.go
@@ -399,9 +399,9 @@ func (o *Orchestrator) pollUntilGone(ctx context.Context, name string, updateFn 
 //   - Degraded or Missing → failure
 //   - ctx cancelled → caller handles via ExitTimeout
 //
-// The first poll happens immediately on entry (before the ticker fires) so
-// stream-error fallback is responsive with no initial delay. Subsequent polls
-// wait for the ticker first so a cancelled context never triggers a wasted RPC.
+// The first poll happens immediately on entry (no initial delay when falling back
+// from a stream error). Subsequent polls wait for the ticker first, so a cancelled
+// context avoids a wasted RPC on each subsequent iteration.
 func (o *Orchestrator) pollUntilTerminal(ctx context.Context, name string, updateFn func(Result)) {
 	ticker := time.NewTicker(o.pollIntervalOrDefault())
 	defer ticker.Stop()

--- a/internal/argocd/grpcsync/orchestrator_test.go
+++ b/internal/argocd/grpcsync/orchestrator_test.go
@@ -3,6 +3,7 @@ package grpcsync
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -45,13 +46,26 @@ func TestDegradedGracePeriodDefault(t *testing.T) {
 
 // fakeAppClient is a test double for appClient.
 // events are sent to the watch channel in order, then the goroutine blocks
-// until ctx is cancelled (simulating a long-lived, quiet watch stream).
+// until ctx is cancelled (simulating a long-lived, quiet watch stream) unless
+// closeStreamAfterEvents is true, in which case the channel is closed after all
+// events are sent (simulating a stream that terminates early).
+//
+// If watchErr is set, WatchApplication returns that error immediately.
+// If detailSeq is set, GetApplication returns elements in order (repeating the
+// last one once the slice is exhausted); otherwise it returns detail.
 type fakeAppClient struct {
-	events []grpcclient.WatchEvent
-	detail *grpcclient.AppDetail
+	events                 []grpcclient.WatchEvent
+	detail                 *grpcclient.AppDetail
+	detailSeq              []*grpcclient.AppDetail
+	detailIdx              atomic.Int64
+	watchErr               error
+	closeStreamAfterEvents bool
 }
 
 func (f *fakeAppClient) WatchApplication(ctx context.Context, _ string) (<-chan grpcclient.WatchEvent, error) {
+	if f.watchErr != nil {
+		return nil, f.watchErr
+	}
 	ch := make(chan grpcclient.WatchEvent, 16)
 	go func() {
 		defer close(ch)
@@ -62,13 +76,24 @@ func (f *fakeAppClient) WatchApplication(ctx context.Context, _ string) (<-chan 
 				return
 			}
 		}
-		// Block until ctx is cancelled — simulates a live stream with no more events.
-		<-ctx.Done()
+		if !f.closeStreamAfterEvents {
+			// Block until ctx is cancelled — simulates a live stream with no more events.
+			<-ctx.Done()
+		}
+		// else: let defer close(ch) run — simulates a stream that closes early.
 	}()
 	return ch, nil
 }
 
 func (f *fakeAppClient) GetApplication(_ context.Context, _ string) (*grpcclient.AppDetail, error) {
+	if len(f.detailSeq) > 0 {
+		idx := int(f.detailIdx.Add(1) - 1)
+		if idx >= len(f.detailSeq) {
+			idx = len(f.detailSeq) - 1
+		}
+		d := *f.detailSeq[idx]
+		return &d, nil
+	}
 	if f.detail == nil {
 		return nil, errors.New("not found")
 	}
@@ -137,6 +162,62 @@ func TestSyncAndWait_DegradedThenProgressing(t *testing.T) {
 		Apps:                []string{"myapp"},
 		Timeout:             10 * time.Second,
 		DegradedGracePeriod: 50 * time.Millisecond, // very short to catch any timer leak
+	})
+	if code != ExitSuccess {
+		t.Fatalf("exit code = %v (%d), want ExitSuccess; results = %+v", code, code, results)
+	}
+	if results[0].Health != "Healthy" {
+		t.Errorf("results[0].Health = %q, want Healthy", results[0].Health)
+	}
+}
+
+// TestSyncAndWait_StreamError_PollsUntilHealthy confirms that when WatchApplication
+// fails (transient gRPC error), SyncAndWait falls back to pollUntilTerminal and
+// waits for Synced+Healthy rather than snapshotting the first intermediate state.
+func TestSyncAndWait_StreamError_PollsUntilHealthy(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAppClient{
+		watchErr: errors.New("stream unavailable"),
+		detailSeq: []*grpcclient.AppDetail{
+			{AppStatus: grpcclient.AppStatus{Name: "myapp", SyncStatus: "Synced", Health: "Progressing"}},
+			{AppStatus: grpcclient.AppStatus{Name: "myapp", SyncStatus: "Synced", Health: "Progressing"}},
+			{AppStatus: grpcclient.AppStatus{Name: "myapp", SyncStatus: "Synced", Health: "Healthy"}},
+		},
+	}
+	orch := &Orchestrator{client: fake, log: zap.NewNop(), pollInterval: time.Millisecond}
+	results, code := orch.SyncAndWait(context.Background(), Request{
+		Apps:    []string{"myapp"},
+		Timeout: 10 * time.Second,
+	})
+	if code != ExitSuccess {
+		t.Fatalf("exit code = %v (%d), want ExitSuccess; results = %+v", code, code, results)
+	}
+	if results[0].Health != "Healthy" {
+		t.Errorf("results[0].Health = %q, want Healthy", results[0].Health)
+	}
+}
+
+// TestSyncAndWait_StreamClose_PollsUntilHealthy confirms that when the Watch
+// stream closes early (before the app is done), SyncAndWait continues polling
+// rather than capturing the intermediate state and exiting.
+func TestSyncAndWait_StreamClose_PollsUntilHealthy(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAppClient{
+		// Stream sends one Progressing event then closes early.
+		events:                 []grpcclient.WatchEvent{
+			{App: grpcclient.AppStatus{Name: "myapp", SyncStatus: "Synced", Health: "Progressing"}},
+		},
+		closeStreamAfterEvents: true,
+		// Poll sequence: still Progressing on first poll, then Healthy.
+		detailSeq: []*grpcclient.AppDetail{
+			{AppStatus: grpcclient.AppStatus{Name: "myapp", SyncStatus: "Synced", Health: "Progressing"}},
+			{AppStatus: grpcclient.AppStatus{Name: "myapp", SyncStatus: "Synced", Health: "Healthy"}},
+		},
+	}
+	orch := &Orchestrator{client: fake, log: zap.NewNop(), pollInterval: time.Millisecond}
+	results, code := orch.SyncAndWait(context.Background(), Request{
+		Apps:    []string{"myapp"},
+		Timeout: 10 * time.Second,
 	})
 	if code != ExitSuccess {
 		t.Fatalf("exit code = %v (%d), want ExitSuccess; results = %+v", code, code, results)

--- a/internal/argocd/grpcsync/orchestrator_test.go
+++ b/internal/argocd/grpcsync/orchestrator_test.go
@@ -207,7 +207,7 @@ func TestSyncAndWait_StreamClose_PollsUntilHealthy(t *testing.T) {
 	t.Parallel()
 	fake := &fakeAppClient{
 		// Stream sends one Progressing event then closes early.
-		events:                 []grpcclient.WatchEvent{
+		events: []grpcclient.WatchEvent{
 			{App: grpcclient.AppStatus{Name: "myapp", SyncStatus: "Synced", Health: "Progressing"}},
 		},
 		closeStreamAfterEvents: true,

--- a/internal/argocd/grpcsync/orchestrator_test.go
+++ b/internal/argocd/grpcsync/orchestrator_test.go
@@ -85,7 +85,10 @@ func (f *fakeAppClient) WatchApplication(ctx context.Context, _ string) (<-chan 
 	return ch, nil
 }
 
-func (f *fakeAppClient) GetApplication(_ context.Context, _ string) (*grpcclient.AppDetail, error) {
+func (f *fakeAppClient) GetApplication(ctx context.Context, _ string) (*grpcclient.AppDetail, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 	if len(f.detailSeq) > 0 {
 		idx := int(f.detailIdx.Add(1) - 1)
 		if idx >= len(f.detailSeq) {


### PR DESCRIPTION
## Problem

When the gRPC Watch stream fails or closes early, `watchSingleApp` fell back to `pollOnce` — a single `GetApplication` snapshot. If the app was still `Progressing` at that moment, the one-shot snapshot would cause `watchApps` to score `ExitTimeout`, even though the app would have reached `Synced+Healthy` shortly after.

## Fix

Replace `pollOnce` with `pollUntilTerminal`, which polls `GetApplication` in a loop until a terminal state is reached or the context expires.

**Terminal states:**
- `Synced+Healthy` → success
- `Degraded` or `Missing` → failure
- ctx cancelled → `ExitTimeout` (existing behaviour)

**Design details:**
- First poll happens immediately on entry — no initial delay when falling back from a stream error
- Subsequent polls wait for the ticker first, so a cancelled context never triggers a wasted RPC (avoids a spurious "poll failed" warning log on timeout)
- `pollInterval` override field (zero → `DefaultPollInterval`) is now applied consistently to `waitForAppear` and `pollUntilGone` as well, which previously hard-coded the constant

## Tests

Two new regression tests covering the previously unhandled fallback paths:

- `TestSyncAndWait_StreamError_PollsUntilHealthy`: `WatchApplication` returns an error; poll sequence goes `Progressing → Progressing → Healthy` → `ExitSuccess`
- `TestSyncAndWait_StreamClose_PollsUntilHealthy`: stream closes after one `Progressing` event; polling continues to `Healthy` → `ExitSuccess`

The `fakeAppClient` test double is extended with `watchErr`, `closeStreamAfterEvents`, and `detailSeq` fields to support these scenarios. `detailIdx` uses `atomic.Int64` to be safe under concurrent multi-app tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

**[Linus Torvalds Mode]** Whoever shipped `pollOnce` as a "fallback" should be ashamed of themselves — a single snapshot of a `Progressing` app is not a fallback, it's a coin flip dressed in a lab coat. At least someone showed up to fix it.

This PR replaces the single-shot `pollOnce` fallback with `pollUntilTerminal`, a loop that calls `GetApplication` until a terminal state is reached or the context expires. The root cause of spurious `ExitTimeout` results (stream fails while app is still `Progressing`, one-shot snapshot captures intermediate state) is now gone. `pollIntervalOrDefault()` is also applied consistently to `waitForAppear` and `pollUntilGone`, which previously hard-coded the constant. Two regression tests cover the stream-error and stream-close fallback paths. Previous review findings on context propagation in the fake and the misleading doc comment have been addressed in `cd43b29`.

**Changes:**
- `pollUntilTerminal` replaces `pollOnce`; first poll fires immediately, subsequent polls wait for ticker (cancellation-safe)
- `pollIntervalOrDefault()` now used consistently in `waitForAppear` and `pollUntilGone`
- `fakeAppClient` extended with `watchErr`, `closeStreamAfterEvents`, `detailSeq`, `atomic.Int64 detailIdx`, and `ctx.Err()` propagation
- Two new regression tests: `TestSyncAndWait_StreamError_PollsUntilHealthy` and `TestSyncAndWait_StreamClose_PollsUntilHealthy`

**Remaining concerns:**
- The terminal-state check in `pollUntilTerminal` treats any `Degraded` (regardless of `SyncStatus`) as immediately terminal, whereas `watchSingleApp` requires `Synced+Degraded` before starting the grace timer and keeps watching on `Progressing+Degraded` — a transient `Progressing+Degraded` during pod restart causes `ExitFailure` in the poll path but continued watching in the stream path
- `Missing` is treated as immediately terminal in `pollUntilTerminal` but falls into the `default` keep-watching case in `watchSingleApp`; the divergence is undocumented

Merge it — just fix the terminal-state inconsistency before someone files a "false failure during pod restart" bug at 2 AM.

<h3>Confidence Score: 5/5</h3>

**[Linus Torvalds Mode]** Whoever shipped pollOnce as a fallback should feel bad about themselves, but at least someone showed up and replaced it with something that actually loops. The PR is safe to merge — the core fix is correct, the tests exercise the broken paths, and the remaining issues are P2 style inconsistencies that aren't going to kill anyone in production tonight.

This looks like it was written by someone who forgot to cross-reference their own watch-path logic when defining terminal states, which is exactly the kind of thing code review exists to catch. That said, the core fix is correct, the two new regression tests actually verify the previously-broken fallback paths, and previous P1 findings (context propagation in fake, misleading doc comment) have been addressed. The Degraded-without-grace-period and Missing-is-immediately-fatal divergences are real but rare-in-practice edge cases in a fallback path. No P0 or P1 blockers remain — score is 5 per the guidance. Frankly the remaining P2s should embarrass the author into fixing them anyway.

`orchestrator.go` lines 422-423 — the terminal-state check is the only thing worth a second look; every docs file in this PR is something I am actively pretending does not exist.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/argocd/grpcsync/orchestrator.go | Replaces single-shot pollOnce with pollUntilTerminal loop; pollIntervalOrDefault now applied consistently; terminal-state check diverges from watchSingleApp for Degraded (no grace period) and Missing (immediately terminal vs. keep-watching) |
| internal/argocd/grpcsync/orchestrator_test.go | Two new regression tests for stream-error and stream-close fallback paths; fakeAppClient extended with watchErr, closeStreamAfterEvents, detailSeq, and proper ctx.Err() propagation |
| docs/superpowers/plans/2026-04-04-argocd-deployment-research.md | Documentation plan file — no code changes |
| docs/superpowers/reports/2026-04-04-argocd-deployment-research-report.md | Research report — no code changes |
| docs/superpowers/research/findings-appworkloads.md | Research findings — no code changes |
| docs/superpowers/research/findings-argocd.md | Research findings — no code changes |
| docs/superpowers/research/findings-go.md | Research findings — no code changes |
| docs/superpowers/research/findings-homelab.md | Research findings — no code changes |
| docs/superpowers/research/findings-k8s.md | Research findings — no code changes |
| docs/superpowers/specs/2026-04-04-argocd-deployment-research-design.md | Design spec — no code changes |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant O as Orchestrator
    participant W as WatchApplication
    participant G as GetApplication

    O->>W: WatchApplication(ctx, name)
    alt Stream error (watchErr set)
        W-->>O: error
        Note over O: Falls back to pollUntilTerminal
        O->>G: poll() [immediate, no delay]
        G-->>O: AppDetail{Progressing}
        loop until terminal or ctx.Done()
            O->>O: wait ticker
            O->>G: poll()
            G-->>O: AppDetail{Healthy}
            Note over O: Synced+Healthy → terminal
            O->>O: return ExitSuccess
        end
    else Stream closes early (channel closed)
        W-->>O: WatchEvent{Progressing}
        W-->>O: channel closed
        Note over O: Falls back to pollUntilTerminal
        O->>G: poll() [immediate, no delay]
        G-->>O: AppDetail{Progressing}
        loop until terminal or ctx.Done()
            O->>O: wait ticker
            O->>G: poll()
            G-->>O: AppDetail{Healthy}
            Note over O: Synced+Healthy → terminal
            O->>O: return ExitSuccess
        end
    else Normal stream — no fallback
        loop until Synced+Healthy or ctx.Done()
            W-->>O: WatchEvent
            O->>O: updateFn(result)
        end
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/argocd/grpcsync/orchestrator.go
Line: 422-423

Comment:
**`Degraded` terminal check skips grace period**

Holy hell, did you even read the function you're supposedly replacing? This is the kind of behavioral divergence that bites you in a midnight incident, not a code review.

In `watchSingleApp`, only `Synced+Degraded` starts the grace timer; `Progressing+Degraded` (common during pod restarts) falls into the `default` case and keeps watching. Here, any `Degraded` health — regardless of `SyncStatus` — terminates immediately as failure. If the stream closes while the app is mid-restart and briefly reports `Progressing+Degraded`, the poll fallback fires `ExitFailure` where the watch path would have kept waiting and eventually seen `Healthy`. The terminal condition should mirror the watch path's `Synced+Degraded` requirement:

```suggestion
		return (detail.SyncStatus == "Synced" && detail.Health == "Healthy") ||
			(detail.SyncStatus == "Synced" && detail.Health == "Degraded") || detail.Health == "Missing"
```

Congratulations on inventing a fallback that's measurably worse than the path it's falling back from.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/argocd/grpcsync/orchestrator.go
Line: 422-423

Comment:
**`Missing` not terminal in watch path**

Either this is a deliberate divergence or nobody looked at the watch loop before writing this — and from what I can tell, it's the latter. Pick one behavior and document it.

In `watchSingleApp`, `Missing` health falls into the `default` case: the grace timer is cleared and the loop keeps watching. In `pollUntilTerminal`, `Missing` terminates immediately as failure. This means the stream path and the poll fallback produce different outcomes for the same transient `Missing` observation. If the divergence is intentional, add a comment explaining why; if not, remove `Missing` from the terminal condition or add it to the watch loop's early-exit cases.

The next person to debug a poll-vs-stream result discrepancy will not thank you.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["style: fix gofumpt alignment in TestSync..."](https://github.com/sikifanso/sikifanso/commit/3c3ffc6138b7930a5c5989a0befb291d9e2e744e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27388017)</sub>

<!-- /greptile_comment -->