### PR TITLE
feat: tier-aware watchApps goroutine sequencing

### DIFF
--- a/cmd/sikifanso/cluster_create.go
+++ b/cmd/sikifanso/cluster_create.go
@@ -125,11 +125,15 @@ func clusterCreateAction(ctx context.Context, cmd *cli.Command) error {
 				if recErr != nil {
 					zapLogger.Warn("post-profile sync: reconciler unavailable", zap.Error(recErr))
 				} else {
+					allApps := make([]string, 0, len(profileApps)+len(autoAdded))
+					allApps = append(allApps, profileApps...)
+					allApps = append(allApps, autoAdded...)
 					orch := grpcsync.NewOrchestrator(client, zapLogger)
 					results, exitCode := orch.SyncAndWait(ctx, grpcsync.Request{
-						Apps:      append(profileApps, autoAdded...),
+						Apps:      allApps,
 						Operation: grpcsync.OpEnable,
 						Prune:     true,
+						AppTiers:  buildAppTiers(sess.GitOpsPath, allApps),
 						ReconcileFn: func(ctx context.Context) error {
 							return reconciler.Trigger(ctx, "catalog")
 						},

--- a/cmd/sikifanso/middleware.go
+++ b/cmd/sikifanso/middleware.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alicanalbayrak/sikifanso/internal/argocd/appsetreconcile"
 	"github.com/alicanalbayrak/sikifanso/internal/argocd/grpcclient"
 	"github.com/alicanalbayrak/sikifanso/internal/argocd/grpcsync"
+	"github.com/alicanalbayrak/sikifanso/internal/catalog"
 	"github.com/alicanalbayrak/sikifanso/internal/kube"
 	"github.com/alicanalbayrak/sikifanso/internal/session"
 	"github.com/urfave/cli/v3"
@@ -108,6 +109,7 @@ func syncAfterMutation(ctx context.Context, cmd *cli.Command, sess *session.Sess
 		Timeout:   cmd.Duration("timeout"),
 		Prune:     true,
 		Operation: opts.Operation,
+		AppTiers:  buildAppTiers(sess.GitOpsPath, opts.Apps),
 		ReconcileFn: func(ctx context.Context) error {
 			return reconciler.Trigger(ctx, opts.AppSetName)
 		},
@@ -180,4 +182,36 @@ func printSyncResults(w io.Writer, results []grpcsync.Result) {
 			}
 		}
 	}
+}
+
+// buildAppTiers returns a map of app name → tier for tier-aware sequencing.
+// Returns nil when gitOpsPath is empty or catalog listing fails (falls back
+// to concurrent mode).
+func buildAppTiers(gitOpsPath string, apps []string) map[string]string {
+	if gitOpsPath == "" {
+		return nil
+	}
+	entries, err := catalog.List(gitOpsPath)
+	if err != nil {
+		zapLogger.Warn("catalog listing failed, falling back to concurrent sync", zap.Error(err))
+		return nil
+	}
+	tierByName := make(map[string]string, len(entries))
+	for _, e := range entries {
+		if e.Tier != "" {
+			tierByName[e.Name] = e.Tier
+		}
+	}
+	result := make(map[string]string, len(apps))
+	hasTier := false
+	for _, name := range apps {
+		if t, ok := tierByName[name]; ok {
+			result[name] = t
+			hasTier = true
+		}
+	}
+	if !hasTier {
+		return nil
+	}
+	return result
 }

--- a/internal/argocd/grpcsync/orchestrator.go
+++ b/internal/argocd/grpcsync/orchestrator.go
@@ -2,6 +2,7 @@ package grpcsync
 
 import (
 	"context"
+	"sort"
 	"sync"
 	"time"
 
@@ -97,9 +98,82 @@ func (o *Orchestrator) SyncOnly(ctx context.Context, req Request) error {
 // watchFn is the per-app strategy used by watchApps.
 type watchFn func(ctx context.Context, name string, req Request, updateFn func(Result))
 
-// watchApps watches all apps concurrently using the given per-app strategy and
-// returns their results plus a composite ExitCode once all goroutines have finished.
+// watchApps watches apps using the given per-app strategy. When req.AppTiers
+// is non-nil, apps are grouped by tier and each tier batch runs sequentially
+// (tier-0 first, then tier-1, etc.). If any tier produces ExitFailure, remaining
+// tiers are skipped. When AppTiers is nil, all apps run concurrently.
 func (o *Orchestrator) watchApps(ctx context.Context, req Request, fn watchFn) ([]Result, ExitCode) {
+	if req.AppTiers == nil {
+		return o.watchAppsConcurrent(ctx, req, fn)
+	}
+
+	// Build index: app name → position in the original Apps slice.
+	idxByName := make(map[string]int, len(req.Apps))
+	for i, name := range req.Apps {
+		idxByName[name] = i
+	}
+
+	// Group apps by tier.
+	tierApps := make(map[string][]string)
+	for _, name := range req.Apps {
+		tier := req.AppTiers[name]
+		if tier == "" {
+			tier = DefaultTier
+		}
+		tierApps[tier] = append(tierApps[tier], name)
+	}
+
+	// Sort tiers lexically: "0-operators" < "1-data" < "2-services".
+	tiers := make([]string, 0, len(tierApps))
+	for t := range tierApps {
+		tiers = append(tiers, t)
+	}
+	sort.Strings(tiers)
+
+	results := make([]Result, len(req.Apps))
+	for i, name := range req.Apps {
+		results[i] = Result{App: name}
+	}
+	compositeCode := ExitSuccess
+
+	for _, tier := range tiers {
+		apps := tierApps[tier]
+		o.log.Info("watching tier", zap.String("tier", tier), zap.Strings("apps", apps))
+
+		// Build a sub-request with only this tier's apps (shares the same context/timeout).
+		tierReq := req
+		tierReq.Apps = apps
+
+		tierResults, tierCode := o.watchAppsConcurrent(ctx, tierReq, fn)
+
+		// Map tier results back into the overall results slice.
+		for j, name := range apps {
+			results[idxByName[name]] = tierResults[j]
+		}
+
+		if tierCode > compositeCode {
+			compositeCode = tierCode
+		}
+
+		// Abort remaining tiers on hard failure — no point deploying services
+		// if their data layer is broken.
+		if tierCode == ExitFailure {
+			o.log.Warn("tier failed, skipping remaining tiers", zap.String("tier", tier))
+			break
+		}
+
+		// Also stop if the context expired (shared timeout pool exhausted).
+		if ctx.Err() != nil {
+			break
+		}
+	}
+
+	return results, compositeCode
+}
+
+// watchAppsConcurrent watches all apps in req.Apps concurrently and returns
+// their results plus a composite ExitCode once all goroutines have finished.
+func (o *Orchestrator) watchAppsConcurrent(ctx context.Context, req Request, fn watchFn) ([]Result, ExitCode) {
 	type entry struct {
 		idx int
 		res Result

--- a/internal/argocd/grpcsync/orchestrator.go
+++ b/internal/argocd/grpcsync/orchestrator.go
@@ -124,11 +124,17 @@ func (o *Orchestrator) watchApps(ctx context.Context, req Request, fn watchFn) (
 	}
 
 	// Sort tiers lexically: "0-operators" < "1-data" < "2-services".
+	// For disable, reverse the order so services come down before their dependencies.
 	tiers := make([]string, 0, len(tierApps))
 	for t := range tierApps {
 		tiers = append(tiers, t)
 	}
 	sort.Strings(tiers)
+	if req.Operation == OpDisable {
+		for i, j := 0, len(tiers)-1; i < j; i, j = i+1, j-1 {
+			tiers[i], tiers[j] = tiers[j], tiers[i]
+		}
+	}
 
 	results := make([]Result, len(req.Apps))
 	for i, name := range req.Apps {

--- a/internal/argocd/grpcsync/orchestrator_test.go
+++ b/internal/argocd/grpcsync/orchestrator_test.go
@@ -266,3 +266,245 @@ func TestSyncAndWait_DegradedPersists(t *testing.T) {
 		t.Error("results[0].Resources is empty — expected resource detail after grace period")
 	}
 }
+
+// --- Tier-aware watchApps tests ---
+
+// multiAppClient is a test double that serves different watch events per app name.
+// It records the order in which WatchApplication is called so tests can verify
+// tier sequencing.
+type multiAppClient struct {
+	// perApp maps app name → events to send on its watch channel.
+	perApp map[string][]grpcclient.WatchEvent
+	// watchOrder records the order of WatchApplication calls (thread-safe via channel).
+	watchOrder chan string
+}
+
+func newMultiAppClient(perApp map[string][]grpcclient.WatchEvent) *multiAppClient {
+	return &multiAppClient{
+		perApp:     perApp,
+		watchOrder: make(chan string, 32),
+	}
+}
+
+func (m *multiAppClient) WatchApplication(ctx context.Context, name string) (<-chan grpcclient.WatchEvent, error) {
+	m.watchOrder <- name
+	events := m.perApp[name]
+	ch := make(chan grpcclient.WatchEvent, len(events)+1)
+	go func() {
+		defer close(ch)
+		for _, e := range events {
+			select {
+			case ch <- e:
+			case <-ctx.Done():
+				return
+			}
+		}
+		<-ctx.Done()
+	}()
+	return ch, nil
+}
+
+func (m *multiAppClient) GetApplication(_ context.Context, name string) (*grpcclient.AppDetail, error) {
+	events := m.perApp[name]
+	if len(events) == 0 {
+		return nil, errors.New("not found")
+	}
+	last := events[len(events)-1]
+	return &grpcclient.AppDetail{
+		AppStatus: last.App,
+	}, nil
+}
+
+func (m *multiAppClient) SyncApplication(_ context.Context, _ string, _ grpcclient.SyncOptions) error {
+	return nil
+}
+
+func (m *multiAppClient) ResourceTree(_ context.Context, _ string) ([]grpcclient.ResourceStatus, error) {
+	return nil, nil
+}
+
+// drainWatchOrder reads all entries from the watchOrder channel (non-blocking)
+// and returns them in order.
+func (m *multiAppClient) drainWatchOrder() []string {
+	var order []string
+	for {
+		select {
+		case name := <-m.watchOrder:
+			order = append(order, name)
+		default:
+			return order
+		}
+	}
+}
+
+// healthyEvent returns a WatchEvent with Synced+Healthy for the given app name.
+func healthyEvent(name string) grpcclient.WatchEvent {
+	return grpcclient.WatchEvent{
+		App: grpcclient.AppStatus{Name: name, SyncStatus: "Synced", Health: "Healthy"},
+	}
+}
+
+// degradedEvent returns a WatchEvent with Synced+Degraded for the given app name.
+func degradedEvent(name string) grpcclient.WatchEvent {
+	return grpcclient.WatchEvent{
+		App: grpcclient.AppStatus{Name: name, SyncStatus: "Synced", Health: "Degraded"},
+	}
+}
+
+// TestWatchApps_TierSequencing verifies that when AppTiers is set, apps are
+// watched in tier order: tier-0 completes before tier-1 starts, etc.
+func TestWatchApps_TierSequencing(t *testing.T) {
+	t.Parallel()
+
+	fake := newMultiAppClient(map[string][]grpcclient.WatchEvent{
+		"cnpg-operator": {healthyEvent("cnpg-operator")},
+		"postgresql":    {healthyEvent("postgresql")},
+		"langfuse":      {healthyEvent("langfuse")},
+	})
+
+	orch := &Orchestrator{client: fake, log: zap.NewNop()}
+	results, code := orch.SyncAndWait(context.Background(), Request{
+		Apps:    []string{"langfuse", "cnpg-operator", "postgresql"},
+		Timeout: 10 * time.Second,
+		AppTiers: map[string]string{
+			"cnpg-operator": "0-operators",
+			"postgresql":    "1-data",
+			"langfuse":      "2-services",
+		},
+	})
+
+	if code != ExitSuccess {
+		t.Fatalf("exit code = %d, want ExitSuccess; results = %+v", code, results)
+	}
+
+	order := fake.drainWatchOrder()
+	if len(order) != 3 {
+		t.Fatalf("watchOrder has %d entries, want 3: %v", len(order), order)
+	}
+
+	// tier-0 must come first, tier-2 must come last.
+	if order[0] != "cnpg-operator" {
+		t.Errorf("first watched app = %q, want cnpg-operator (tier-0)", order[0])
+	}
+	if order[1] != "postgresql" {
+		t.Errorf("second watched app = %q, want postgresql (tier-1)", order[1])
+	}
+	if order[2] != "langfuse" {
+		t.Errorf("third watched app = %q, want langfuse (tier-2)", order[2])
+	}
+}
+
+// TestWatchApps_TierFailureAbortsRemaining verifies that if a tier-0 app
+// fails (Degraded), tier-1 and tier-2 apps are never watched.
+func TestWatchApps_TierFailureAbortsRemaining(t *testing.T) {
+	t.Parallel()
+
+	fake := newMultiAppClient(map[string][]grpcclient.WatchEvent{
+		"cnpg-operator": {degradedEvent("cnpg-operator")},
+		"postgresql":    {healthyEvent("postgresql")},
+		"langfuse":      {healthyEvent("langfuse")},
+	})
+
+	orch := &Orchestrator{client: fake, log: zap.NewNop()}
+	results, code := orch.SyncAndWait(context.Background(), Request{
+		Apps:    []string{"langfuse", "cnpg-operator", "postgresql"},
+		Timeout: 10 * time.Second,
+		AppTiers: map[string]string{
+			"cnpg-operator": "0-operators",
+			"postgresql":    "1-data",
+			"langfuse":      "2-services",
+		},
+		DegradedGracePeriod: 50 * time.Millisecond, // short for test speed
+	})
+
+	if code != ExitFailure {
+		t.Fatalf("exit code = %d, want ExitFailure; results = %+v", code, results)
+	}
+
+	order := fake.drainWatchOrder()
+	// Only tier-0 should have been watched — tier-1 and tier-2 should be skipped.
+	if len(order) != 1 {
+		t.Fatalf("watchOrder has %d entries, want 1 (only tier-0): %v", len(order), order)
+	}
+	if order[0] != "cnpg-operator" {
+		t.Errorf("watched app = %q, want cnpg-operator", order[0])
+	}
+
+	// Verify that skipped apps still have their initial empty results.
+	for _, r := range results {
+		if r.App == "langfuse" && r.Health == "Healthy" {
+			t.Error("langfuse should not have been watched")
+		}
+		if r.App == "postgresql" && r.Health == "Healthy" {
+			t.Error("postgresql should not have been watched")
+		}
+	}
+}
+
+// TestWatchApps_NilAppTiers_Concurrent verifies backward compatibility:
+// when AppTiers is nil, all apps are watched concurrently.
+func TestWatchApps_NilAppTiers_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	fake := newMultiAppClient(map[string][]grpcclient.WatchEvent{
+		"app-a": {healthyEvent("app-a")},
+		"app-b": {healthyEvent("app-b")},
+		"app-c": {healthyEvent("app-c")},
+	})
+
+	orch := &Orchestrator{client: fake, log: zap.NewNop()}
+	results, code := orch.SyncAndWait(context.Background(), Request{
+		Apps:    []string{"app-a", "app-b", "app-c"},
+		Timeout: 10 * time.Second,
+		// AppTiers is nil — concurrent mode.
+	})
+
+	if code != ExitSuccess {
+		t.Fatalf("exit code = %d, want ExitSuccess; results = %+v", code, results)
+	}
+	if len(results) != 3 {
+		t.Fatalf("len(results) = %d, want 3", len(results))
+	}
+	for _, r := range results {
+		if r.Health != "Healthy" {
+			t.Errorf("app %s health = %q, want Healthy", r.App, r.Health)
+		}
+	}
+}
+
+// TestWatchApps_DefaultTier verifies that apps missing from AppTiers map
+// are placed into the default tier (0-operators).
+func TestWatchApps_DefaultTier(t *testing.T) {
+	t.Parallel()
+
+	fake := newMultiAppClient(map[string][]grpcclient.WatchEvent{
+		"untiered-app": {healthyEvent("untiered-app")},
+		"langfuse":     {healthyEvent("langfuse")},
+	})
+
+	orch := &Orchestrator{client: fake, log: zap.NewNop()}
+	results, code := orch.SyncAndWait(context.Background(), Request{
+		Apps:    []string{"langfuse", "untiered-app"},
+		Timeout: 10 * time.Second,
+		AppTiers: map[string]string{
+			// untiered-app is not in the map — should default to "0-operators"
+			"langfuse": "2-services",
+		},
+	})
+
+	if code != ExitSuccess {
+		t.Fatalf("exit code = %d, want ExitSuccess; results = %+v", code, results)
+	}
+
+	order := fake.drainWatchOrder()
+	if len(order) != 2 {
+		t.Fatalf("watchOrder has %d entries, want 2: %v", len(order), order)
+	}
+	// untiered-app → tier-0 (default), langfuse → tier-2; so untiered first.
+	if order[0] != "untiered-app" {
+		t.Errorf("first watched = %q, want untiered-app (default tier-0)", order[0])
+	}
+	if order[1] != "langfuse" {
+		t.Errorf("second watched = %q, want langfuse (tier-2)", order[1])
+	}
+}

--- a/internal/argocd/grpcsync/orchestrator_test.go
+++ b/internal/argocd/grpcsync/orchestrator_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/alicanalbayrak/sikifanso/internal/argocd/grpcclient"
 )
@@ -351,26 +353,57 @@ func degradedEvent(name string) grpcclient.WatchEvent {
 	}
 }
 
-// TestWatchApps_TierSequencing verifies that when AppTiers is set, apps are
-// watched in tier order: tier-0 completes before tier-1 starts, etc.
+// assertInterTierOrder checks that every app in an earlier tier appears before
+// every app in a later tier within the watchOrder slice. Intra-tier order is
+// nondeterministic (goroutines launch concurrently within a tier).
+func assertInterTierOrder(t *testing.T, order []string, tiers map[string]string) {
+	t.Helper()
+	indexOf := make(map[string]int, len(order))
+	for i, name := range order {
+		indexOf[name] = i
+	}
+	for a, tierA := range tiers {
+		for b, tierB := range tiers {
+			if tierA < tierB {
+				idxA, okA := indexOf[a]
+				idxB, okB := indexOf[b]
+				if okA && okB && idxA >= idxB {
+					t.Errorf("tier ordering violated: %s (tier %s, pos %d) should appear before %s (tier %s, pos %d)",
+						a, tierA, idxA, b, tierB, idxB)
+				}
+			}
+		}
+	}
+}
+
+// TestWatchApps_TierSequencing verifies that when AppTiers is set, all apps
+// in an earlier tier are watched before any app in a later tier.
+// Uses multiple apps per tier to exercise intra-tier concurrency.
 func TestWatchApps_TierSequencing(t *testing.T) {
 	t.Parallel()
 
-	fake := newMultiAppClient(map[string][]grpcclient.WatchEvent{
-		"cnpg-operator": {healthyEvent("cnpg-operator")},
-		"postgresql":    {healthyEvent("postgresql")},
-		"langfuse":      {healthyEvent("langfuse")},
-	})
+	appTiers := map[string]string{
+		"cnpg-operator": "0-operators",
+		"cert-manager":  "0-operators",
+		"postgresql":    "1-data",
+		"valkey":        "1-data",
+		"langfuse":      "2-services",
+		"litellm-proxy": "2-services",
+	}
 
+	perApp := make(map[string][]grpcclient.WatchEvent, len(appTiers))
+	apps := make([]string, 0, len(appTiers))
+	for name := range appTiers {
+		perApp[name] = []grpcclient.WatchEvent{healthyEvent(name)}
+		apps = append(apps, name)
+	}
+
+	fake := newMultiAppClient(perApp)
 	orch := &Orchestrator{client: fake, log: zap.NewNop()}
 	results, code := orch.SyncAndWait(context.Background(), Request{
-		Apps:    []string{"langfuse", "cnpg-operator", "postgresql"},
-		Timeout: 10 * time.Second,
-		AppTiers: map[string]string{
-			"cnpg-operator": "0-operators",
-			"postgresql":    "1-data",
-			"langfuse":      "2-services",
-		},
+		Apps:     apps,
+		Timeout:  10 * time.Second,
+		AppTiers: appTiers,
 	})
 
 	if code != ExitSuccess {
@@ -378,20 +411,11 @@ func TestWatchApps_TierSequencing(t *testing.T) {
 	}
 
 	order := fake.drainWatchOrder()
-	if len(order) != 3 {
-		t.Fatalf("watchOrder has %d entries, want 3: %v", len(order), order)
+	if len(order) != len(apps) {
+		t.Fatalf("watchOrder has %d entries, want %d: %v", len(order), len(apps), order)
 	}
 
-	// tier-0 must come first, tier-2 must come last.
-	if order[0] != "cnpg-operator" {
-		t.Errorf("first watched app = %q, want cnpg-operator (tier-0)", order[0])
-	}
-	if order[1] != "postgresql" {
-		t.Errorf("second watched app = %q, want postgresql (tier-1)", order[1])
-	}
-	if order[2] != "langfuse" {
-		t.Errorf("third watched app = %q, want langfuse (tier-2)", order[2])
-	}
+	assertInterTierOrder(t, order, appTiers)
 }
 
 // TestWatchApps_TierFailureAbortsRemaining verifies that if a tier-0 app
@@ -500,11 +524,83 @@ func TestWatchApps_DefaultTier(t *testing.T) {
 	if len(order) != 2 {
 		t.Fatalf("watchOrder has %d entries, want 2: %v", len(order), order)
 	}
-	// untiered-app → tier-0 (default), langfuse → tier-2; so untiered first.
-	if order[0] != "untiered-app" {
-		t.Errorf("first watched = %q, want untiered-app (default tier-0)", order[0])
+	// untiered-app defaults to "0-operators", langfuse is "2-services".
+	assertInterTierOrder(t, order, map[string]string{
+		"untiered-app": DefaultTier,
+		"langfuse":     "2-services",
+	})
+}
+
+// TestWatchApps_DisableReversesOrder verifies that OpDisable reverses tier
+// ordering so services are torn down before their dependencies.
+func TestWatchApps_DisableReversesOrder(t *testing.T) {
+	t.Parallel()
+
+	deletedClient := &alreadyDeletedClient{watchOrder: make(chan string, 32)}
+
+	orch := &Orchestrator{client: deletedClient, log: zap.NewNop()}
+	appTiers := map[string]string{
+		"cnpg-operator": "0-operators",
+		"postgresql":    "1-data",
+		"langfuse":      "2-services",
 	}
-	if order[1] != "langfuse" {
-		t.Errorf("second watched = %q, want langfuse (tier-2)", order[1])
+	results, code := orch.SyncAndWait(context.Background(), Request{
+		Apps:      []string{"cnpg-operator", "postgresql", "langfuse"},
+		Timeout:   10 * time.Second,
+		Operation: OpDisable,
+		AppTiers:  appTiers,
+	})
+
+	if code != ExitSuccess {
+		t.Fatalf("exit code = %d, want ExitSuccess; results = %+v", code, results)
+	}
+
+	order := deletedClient.drainWatchOrder()
+	if len(order) != 3 {
+		t.Fatalf("watchOrder has %d entries, want 3: %v", len(order), order)
+	}
+
+	// For disable, tier order is reversed: 2-services before 1-data before 0-operators.
+	// Use reverse tier keys for the inter-tier assertion.
+	reverseTiers := map[string]string{
+		"langfuse":      "0-first",  // 2-services should be watched first
+		"postgresql":    "1-second", // 1-data second
+		"cnpg-operator": "2-third",  // 0-operators last
+	}
+	assertInterTierOrder(t, order, reverseTiers)
+}
+
+// alreadyDeletedClient reports all apps as not found (already deleted),
+// so waitForDisappear returns immediately. Tracks watch order for sequencing tests.
+type alreadyDeletedClient struct {
+	watchOrder chan string
+}
+
+func (a *alreadyDeletedClient) WatchApplication(_ context.Context, _ string) (<-chan grpcclient.WatchEvent, error) {
+	return nil, errors.New("not found")
+}
+
+func (a *alreadyDeletedClient) GetApplication(_ context.Context, name string) (*grpcclient.AppDetail, error) {
+	a.watchOrder <- name
+	return nil, status.Error(codes.NotFound, "app not found")
+}
+
+func (a *alreadyDeletedClient) SyncApplication(_ context.Context, _ string, _ grpcclient.SyncOptions) error {
+	return nil
+}
+
+func (a *alreadyDeletedClient) ResourceTree(_ context.Context, _ string) ([]grpcclient.ResourceStatus, error) {
+	return nil, nil
+}
+
+func (a *alreadyDeletedClient) drainWatchOrder() []string {
+	var order []string
+	for {
+		select {
+		case name := <-a.watchOrder:
+			order = append(order, name)
+		default:
+			return order
+		}
 	}
 }

--- a/internal/argocd/grpcsync/types.go
+++ b/internal/argocd/grpcsync/types.go
@@ -37,7 +37,15 @@ type Request struct {
 	// DegradedGracePeriod is how long SyncAndWait tolerates Synced+Degraded before
 	// reporting failure. Zero is replaced by DefaultDegradedGracePeriod.
 	DegradedGracePeriod time.Duration
+	// AppTiers maps app name → tier string (e.g. "0-operators", "1-data", "2-services").
+	// When non-nil, watchApps sequences goroutine launches by tier: all tier-0 apps
+	// are watched first; tier-1 starts only after tier-0 completes successfully, etc.
+	// Apps missing from the map default to DefaultTier. When nil, all apps run concurrently.
+	AppTiers map[string]string
 }
+
+// DefaultTier is assigned to apps with no explicit tier.
+const DefaultTier = "0-operators"
 
 // Result holds the observed state of a single application after a sync operation.
 type Result struct {


### PR DESCRIPTION
## Summary

- `watchApps` now sequences goroutine launches by tier when `AppTiers` metadata is provided, matching ArgoCD's RollingSync ordering (`0-operators` → `1-data` → `2-services`)
- Prevents spurious timeout reports for apps legitimately held in the RollingSync queue
- Backward compatible: when `AppTiers` is nil, all apps run concurrently as before

## Changes

- **`grpcsync/types.go`**: Added `AppTiers map[string]string` to `Request` and `DefaultTier` constant
- **`grpcsync/orchestrator.go`**: Extracted `watchAppsConcurrent` from `watchApps`; new `watchApps` groups apps by tier, sorts lexically, runs each batch sequentially. Aborts remaining tiers on `ExitFailure`
- **`middleware.go`**: Added `buildAppTiers()` helper that loads tier info from catalog entries; wired into `syncAfterMutation`
- **`cluster_create.go`**: Post-profile sync now passes tier metadata
- **`orchestrator_test.go`**: 4 new tests covering tier sequencing, failure abort, backward compat, and default tier fallback

## Test plan

- [x] `go test ./... -race` — all pass
- [x] `make lint` — 0 issues
- [ ] Manual: `sikifanso cluster create --profile agent-minimal` — verify tier-0 operators deploy before tier-1/2 apps in logs
- [ ] Manual: `sikifanso app enable langfuse` — verify tier-aware sequencing when enabling with auto-deps

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

**[Linus Torvalds Mode]** Well, well — somebody actually thought about goroutine ordering instead of just throwing `go func()` at every problem and calling it distributed systems. This PR introduces tier-aware sequencing in `watchApps` so ArgoCD apps deploy in RollingSync order (`0-operators` → `1-data` → `2-services`), aborting subsequent tiers on hard failure and correctly reversing the order for `OpDisable`. Backward compatibility is maintained when `AppTiers` is nil.

Key changes:
- `types.go`: `AppTiers map[string]string` added to `Request`; `DefaultTier = "0-operators"` constant introduced
- `orchestrator.go`: `watchApps` now sequences tiers lexically and concurrently within each tier; `watchAppsConcurrent` extracted as the inner engine
- `middleware.go`: `buildAppTiers()` loads tier metadata from catalog entries and wires it into `syncAfterMutation`
- `cluster_create.go`: Post-profile sync now passes tier metadata
- `orchestrator_test.go`: 4 new tests covering sequencing, failure abort, backward compat, and default-tier fallback — including the `assertInterTierOrder` helper that correctly avoids fragile positional assertions

Two minor P2 issues remain: the `ExitTimeout` abort path relies on an undocumented invariant, and `buildAppTiers` silently promotes untiered apps to `DefaultTier` with no logging — take it or leave it, you'll find out the hard way either way.

<h3>Confidence Score: 5/5</h3>

**[Linus Torvalds Mode]** Somebody finally wrote a PR that doesn't make me feel like I'm debugging production at 2am — tier sequencing logic is correct, tests cover the interesting cases, backward compat is intact. Two P2 nits only; safe to merge.

Genuinely refreshing to see goroutine sequencing done without race conditions or channel leaks. The tier loop correctly handles ExitFailure abort and ExitTimeout via ctx.Err(); all watchFn implementations uphold the invariant that ExitTimeout implies ctx cancellation. The assertInterTierOrder helper makes tests robust to intra-tier concurrency. Both remaining findings are P2: an implicit correctness invariant that should be documented, and a missing debug log for silent DefaultTier promotion. Neither will blow up production. Default confidence score per guidance when all findings are P2.

Keep your eyes on orchestrator.go's tier loop (implicit ExitTimeout invariant) and middleware.go's buildAppTiers (silent DefaultTier promotion for untiered apps). Everything else is fine — assuming you actually trust your own test suite.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/argocd/grpcsync/orchestrator.go | Core tier-sequencing logic is correct; ExitTimeout abort relies on an implicit, undocumented invariant across all watchFn implementations |
| internal/argocd/grpcsync/orchestrator_test.go | Solid test coverage — sequencing, failure abort, backward compat, reverse-disable, default-tier fallback; assertInterTierOrder helper correctly avoids fragile positional assertions |
| cmd/sikifanso/middleware.go | buildAppTiers silently promotes untiered apps to DefaultTier with no logging; partial coverage could produce surprising deployment ordering without any operator-visible warning |
| internal/argocd/grpcsync/types.go | Clean AppTiers field and DefaultTier constant additions; contract is well-documented in comments |
| cmd/sikifanso/cluster_create.go | Correctly wires buildAppTiers into the post-profile sync path; no issues |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller (SyncAndWait)
    participant WA as watchApps
    participant WC as watchAppsConcurrent
    participant WF as watchFn (per-app)

    C->>WA: req (AppTiers non-nil)
    WA->>WA: group apps by tier, sort lexically
    note over WA: OpDisable → reverse sort
    loop for each tier (sequential)
        WA->>WC: tierReq (this tier's apps)
        par per-app goroutine
            WC->>WF: watchSingleApp / waitForAppear / waitForDisappear
            WF-->>WC: Result (Healthy / Degraded / Deleted / ctx cancelled)
        end
        WC-->>WA: []Result, tierCode
        alt tierCode == ExitFailure
            WA->>WA: log + break (abort remaining tiers)
        else ctx.Err() != nil
            WA->>WA: break (ExitTimeout — ctx cancelled)
        end
    end
    WA-->>C: []Result, compositeCode
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `cmd/sikifanso/middleware.go`, line 107-113 ([link](https://github.com/sikifanso/sikifanso/blob/a93a5f1ca29d607c7c65d5488875f69dcf23607b/cmd/sikifanso/middleware.go#L107-L113)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`AppTiers` order wrong for disable**

   Half-baked — tier ordering for disable is simply backwards. Services before operators on teardown, not the reverse.

   `buildAppTiers` is applied unconditionally for all operations, including `OpDisable`. Forward tier ordering (`0-operators` → `1-data` → `2-services`) is correct for enable. For disable, correct teardown reverses that — services must come down before data, data before operators. This code has `watchApps` observing tier-0 operator deletion first while tier-2 services are still live. Pass `nil` for `OpDisable`, reverse the tier keys for disable, or at minimum document that `AppTiers` ordering is only semantically correct for enable/sync operations.

   Congratulations — you will delete operators while services still scream.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: cmd/sikifanso/middleware.go
   Line: 107-113

   Comment:
   **`AppTiers` order wrong for disable**

   Half-baked — tier ordering for disable is simply backwards. Services before operators on teardown, not the reverse.

   `buildAppTiers` is applied unconditionally for all operations, including `OpDisable`. Forward tier ordering (`0-operators` → `1-data` → `2-services`) is correct for enable. For disable, correct teardown reverses that — services must come down before data, data before operators. This code has `watchApps` observing tier-0 operator deletion first while tier-2 services are still live. Pass `nil` for `OpDisable`, reverse the tier keys for disable, or at minimum document that `AppTiers` ordering is only semantically correct for enable/sync operations.

   Congratulations — you will delete operators while services still scream.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/argocd/grpcsync/orchestrator.go
Line: 160-174

Comment:
**`ExitTimeout` abort relies on an undocumented invariant**

This is correctness held together by a gentleman's agreement that nobody wrote down. One future `watchFn` that exits early without ctx cancellation and the whole sequencing guarantee collapses silently.

The `ExitTimeout` case is not explicitly aborted — the loop falls through to the `ctx.Err() != nil` guard. This works today only because every `watchFn` implementation (`watchSingleApp`, `waitForAppear`, `waitForDisappear`) returns a non-terminal result **exclusively** when `ctx` is cancelled. That invariant is invisible to future maintainers. A new `watchFn` with a circuit-breaker or max-retry exit would silently launch subsequent tiers after an "ExitTimeout" that has nothing to do with context expiry.

Either unify the abort condition or document the invariant explicitly:

```suggestion
		if tierCode > compositeCode {
			compositeCode = tierCode
		}

		// Abort remaining tiers on hard failure.
		if tierCode == ExitFailure {
			o.log.Warn("tier failed, skipping remaining tiers", zap.String("tier", tier))
			break
		}

		// ExitTimeout implies ctx is cancelled (all watchFn implementations only return
		// ExitTimeout when ctx.Done fires). The ctx.Err check below catches that case.
		if ctx.Err() != nil {
			break
		}
```

Future you will appreciate the comment when you've forgotten this invariant exists.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: cmd/sikifanso/middleware.go
Line: 205-216

Comment:
**Silent `DefaultTier` promotion for untiered apps**

This is implicit behavior wearing a documentation hat and calling itself a feature. Zero-tier apps becoming operators-tier with no log line is exactly the kind of footgun that takes three hours to diagnose when someone asks why `langfuse` deployed before `postgresql`.

`buildAppTiers` returns a non-nil map even when only a subset of `apps` have catalog tier metadata. Apps absent from the result map are silently assigned `DefaultTier = "0-operators"` inside `watchApps`. If a real service without a catalog tier entry happens to be in the list, it deploys in tier-0 alongside operators — no warning emitted. At minimum, log the apps being defaulted:

```suggestion
	result := make(map[string]string, len(apps))
	hasTier := false
	for _, name := range apps {
		if t, ok := tierByName[name]; ok {
			result[name] = t
			hasTier = true
		} else {
			zapLogger.Debug("app has no tier in catalog, defaulting to tier-0",
				zap.String("app", name), zap.String("default_tier", grpcsync.DefaultTier))
		}
	}
```

At least future you has a log line to blame instead of a mystery deployment order.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: reverse tier order for OpDisable an..."](https://github.com/sikifanso/sikifanso/commit/0c9ec125d2a1c733dfd1a8799995fb4e993a8dd4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27391676)</sub>

<!-- /greptile_comment -->