### PR TITLE
fix: gRPC readiness probe after ArgoCD install

### DIFF
--- a/docs/superpowers/reports/2026-04-04-argocd-deployment-progress.md
+++ b/docs/superpowers/reports/2026-04-04-argocd-deployment-progress.md
@@ -13,7 +13,7 @@
 | P1 | Critical | watchSingleApp exits on transient Degraded | **Done** | `6f30eb2` — Degraded grace period |
 | P2 | Critical | Cluster create post-profile sync uses wrong op | **Done** | `bfe0804` — use OpEnable; `46bc029` — include auto-added deps |
 | P3 | Critical | Catalog ApplicationSet has no automated SyncPolicy | **Done** | Part of `62cf234` — selfHeal + prune added to root-catalog.yaml |
-| P4 | High | ArgoCD webhook/gRPC not ready after install | Open | |
+| P4 | High | ArgoCD webhook/gRPC not ready after install | **Done** | gRPC Version probe between waitForDeployments and CreateApplications |
 | P5 | High | Hardcoded ~/.kube/config in Install/CreateApplications | **Done** | Thread *rest.Config via kube.RESTConfigForCluster |
 | P6 | High | RollingSync tier ordering ignored by CLI + missing tiers | **Done** | `62cf234` — RollingSync + dependency graph |
 | P7 | High | agent-minimal missing valkey | **Done** | `43edb58` — add valkey to agent-minimal |
@@ -51,8 +51,8 @@
 | T7 | High | Add valkey to agent-minimal + langfuse dependsOn | **Done** | P7 |
 | T8 | High | Fix presidio analyzer memory limit | **Done** | P9 — PR #25 |
 | T9 | Medium | Replace pollOnce with retry loop | **Done** | P10 |
-| T10 | Medium | Tier-aware watchApps goroutine sequencing | Open | P6 |
-| T11 | Medium | ArgoCD gRPC readiness probe after install | Open | P4 |
+| T10 | Medium | Tier-aware watchApps goroutine sequencing | **Done** | P6 — PR #13; tier-aware sequencing + reverse order for disable |
+| T11 | Medium | ArgoCD gRPC readiness probe after install | **Done** | P4 — WaitForGRPC polls Version endpoint; installInfra extracted from Create |
 | T12 | Medium | Startup ApplicationSet sequencing in cluster create | Open | P17 |
 | T13 | Medium | Actionable error messages from Result slice | Open | P13 |
 | T14 | Medium | Fix spinner data race + multi-app progress | Open | P15 |
@@ -64,8 +64,8 @@
 
 ## Summary
 
-- **Completed**: 12/17 tasks (T1–T9 + associated review fixes)
+- **Completed**: 14/17 tasks (T1–T11 + associated review fixes)
 - **Remaining Critical**: 0
 - **Remaining High**: 0
-- **Remaining Medium**: 8 (T10–T17)
+- **Remaining Medium**: 6 (T12–T17)
 - **Low (no task)**: 2 (P24, P25)

--- a/internal/argocd/install.go
+++ b/internal/argocd/install.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/alicanalbayrak/sikifanso/internal/helm"
 	"github.com/alicanalbayrak/sikifanso/internal/infraconfig"
+	"github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	"github.com/briandowns/spinner"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/emptypb"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -136,6 +138,58 @@ func deploymentAvailable(dep *appsv1.Deployment) bool {
 		}
 	}
 	return false
+}
+
+var (
+	grpcReadyTimeout  = 30 * time.Second
+	grpcRetryInterval = 2 * time.Second
+)
+
+// WaitForGRPC polls the ArgoCD Version endpoint until the gRPC server
+// responds. Deployment readiness alone does not guarantee that the gRPC
+// listener (and admission webhook) are fully initialised — this probe
+// closes the gap between pod readiness and application-level readiness.
+func WaitForGRPC(ctx context.Context, log *zap.Logger, addr string) error {
+	ctx, cancel := context.WithTimeout(ctx, grpcReadyTimeout)
+	defer cancel()
+
+	log.Info("waiting for ArgoCD gRPC server", zap.String("addr", addr))
+
+	for {
+		if err := probeGRPC(ctx, addr); err == nil {
+			log.Info("ArgoCD gRPC server is ready")
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for ArgoCD gRPC at %s", addr)
+		case <-time.After(grpcRetryInterval):
+		}
+	}
+}
+
+// probeGRPC attempts a single unauthenticated Version call. Version is the
+// lightest ArgoCD gRPC endpoint and requires no auth token, making it safe
+// to call before credentials are used.
+func probeGRPC(ctx context.Context, addr string) error {
+	c, err := apiclient.NewClient(&apiclient.ClientOptions{
+		ServerAddr: addr,
+		Insecure:   true,
+		PlainText:  true,
+	})
+	if err != nil {
+		return err
+	}
+
+	conn, versionClient, err := c.NewVersionClient()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+
+	_, err = versionClient.Version(ctx, &emptypb.Empty{})
+	return err
 }
 
 // extractAdminPassword reads the initial admin password from the

--- a/internal/argocd/install.go
+++ b/internal/argocd/install.go
@@ -155,8 +155,17 @@ func WaitForGRPC(ctx context.Context, log *zap.Logger, addr string) error {
 
 	log.Info("waiting for ArgoCD gRPC server", zap.String("addr", addr))
 
+	c, err := apiclient.NewClient(&apiclient.ClientOptions{
+		ServerAddr: addr,
+		Insecure:   true,
+		PlainText:  true,
+	})
+	if err != nil {
+		return fmt.Errorf("creating ArgoCD probe client: %w", err)
+	}
+
 	for {
-		if err := probeGRPC(ctx, addr); err == nil {
+		if err := probeVersion(ctx, c); err == nil {
 			log.Info("ArgoCD gRPC server is ready")
 			return nil
 		}
@@ -169,19 +178,10 @@ func WaitForGRPC(ctx context.Context, log *zap.Logger, addr string) error {
 	}
 }
 
-// probeGRPC attempts a single unauthenticated Version call. Version is the
-// lightest ArgoCD gRPC endpoint and requires no auth token, making it safe
-// to call before credentials are used.
-func probeGRPC(ctx context.Context, addr string) error {
-	c, err := apiclient.NewClient(&apiclient.ClientOptions{
-		ServerAddr: addr,
-		Insecure:   true,
-		PlainText:  true,
-	})
-	if err != nil {
-		return err
-	}
-
+// probeVersion issues a single unauthenticated Version call on an existing
+// client. Version is the lightest ArgoCD gRPC endpoint and requires no auth
+// token, making it safe to call before credentials are used.
+func probeVersion(ctx context.Context, c apiclient.Client) error {
 	conn, versionClient, err := c.NewVersionClient()
 	if err != nil {
 		return err

--- a/internal/argocd/install.go
+++ b/internal/argocd/install.go
@@ -155,7 +155,7 @@ func WaitForGRPC(ctx context.Context, log *zap.Logger, addr string) error {
 
 	log.Info("waiting for ArgoCD gRPC server", zap.String("addr", addr))
 
-	c, err := apiclient.NewClient(&apiclient.ClientOptions{
+	client, err := apiclient.NewClient(&apiclient.ClientOptions{
 		ServerAddr: addr,
 		Insecure:   true,
 		PlainText:  true,
@@ -165,7 +165,7 @@ func WaitForGRPC(ctx context.Context, log *zap.Logger, addr string) error {
 	}
 
 	for {
-		if err := probeVersion(ctx, c); err == nil {
+		if err := probeVersion(ctx, client); err == nil {
 			log.Info("ArgoCD gRPC server is ready")
 			return nil
 		}

--- a/internal/argocd/install.go
+++ b/internal/argocd/install.go
@@ -168,6 +168,8 @@ func WaitForGRPC(ctx context.Context, log *zap.Logger, addr string) error {
 		if err := probeVersion(ctx, client); err == nil {
 			log.Info("ArgoCD gRPC server is ready")
 			return nil
+		} else {
+			log.Debug("ArgoCD gRPC probe failed, retrying", zap.Error(err))
 		}
 
 		select {

--- a/internal/argocd/install_test.go
+++ b/internal/argocd/install_test.go
@@ -75,22 +75,33 @@ func TestWaitForGRPC_DelayedStart(t *testing.T) {
 	ctx := context.Background()
 	log := zaptest.NewLogger(t)
 
-	// Start the server after a short delay.
+	// Start the server after a short delay. Use a channel to detect listen
+	// failures so we don't call t.Logf on a potentially finished test.
 	srv := grpc.NewServer()
 	versionpkg.RegisterVersionServiceServer(srv, &fakeVersionServer{})
+	listenErr := make(chan error, 1)
 
 	go func() {
 		time.Sleep(2 * time.Second)
 		lis2, err := net.Listen("tcp", addr)
 		if err != nil {
-			t.Logf("re-listen: %v", err)
+			listenErr <- err
 			return
 		}
+		listenErr <- nil
 		_ = srv.Serve(lis2)
 	}()
-	defer srv.GracefulStop()
+	t.Cleanup(srv.GracefulStop)
 
 	if err := WaitForGRPC(ctx, log, addr); err != nil {
+		// Check if the goroutine failed to re-listen before blaming WaitForGRPC.
+		select {
+		case lErr := <-listenErr:
+			if lErr != nil {
+				t.Skipf("port %s was reclaimed by OS: %v", addr, lErr)
+			}
+		default:
+		}
 		t.Fatalf("WaitForGRPC should succeed after delayed start: %v", err)
 	}
 }

--- a/internal/argocd/install_test.go
+++ b/internal/argocd/install_test.go
@@ -1,0 +1,96 @@
+package argocd
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	versionpkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/version"
+	"go.uber.org/zap/zaptest"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// fakeVersionServer implements the ArgoCD VersionService for testing.
+type fakeVersionServer struct {
+	versionpkg.UnimplementedVersionServiceServer
+}
+
+func (f *fakeVersionServer) Version(_ context.Context, _ *emptypb.Empty) (*versionpkg.VersionMessage, error) {
+	return &versionpkg.VersionMessage{Version: "v2.99.0-test"}, nil
+}
+
+func startFakeVersionServer(t *testing.T) (addr string, stop func()) {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := grpc.NewServer()
+	versionpkg.RegisterVersionServiceServer(srv, &fakeVersionServer{})
+	go func() { _ = srv.Serve(lis) }()
+	return lis.Addr().String(), srv.GracefulStop
+}
+
+func TestWaitForGRPC_Success(t *testing.T) {
+	addr, stop := startFakeVersionServer(t)
+	defer stop()
+
+	ctx := context.Background()
+	log := zaptest.NewLogger(t)
+
+	if err := WaitForGRPC(ctx, log, addr); err != nil {
+		t.Fatalf("WaitForGRPC should succeed: %v", err)
+	}
+}
+
+func TestWaitForGRPC_Timeout(t *testing.T) {
+	// Use an address where nothing is listening.
+	addr := "127.0.0.1:1" // port 1 is almost certainly not running a gRPC server
+
+	ctx := context.Background()
+	log := zaptest.NewLogger(t)
+
+	// Override timeout to keep the test fast.
+	origTimeout := grpcReadyTimeout
+	grpcReadyTimeout = 3 * time.Second
+	defer func() { grpcReadyTimeout = origTimeout }()
+
+	err := WaitForGRPC(ctx, log, addr)
+	if err == nil {
+		t.Fatal("WaitForGRPC should have timed out")
+	}
+}
+
+func TestWaitForGRPC_DelayedStart(t *testing.T) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := lis.Addr().String()
+	// Close immediately — nothing is serving yet.
+	_ = lis.Close()
+
+	ctx := context.Background()
+	log := zaptest.NewLogger(t)
+
+	// Start the server after a short delay.
+	srv := grpc.NewServer()
+	versionpkg.RegisterVersionServiceServer(srv, &fakeVersionServer{})
+
+	go func() {
+		time.Sleep(2 * time.Second)
+		lis2, err := net.Listen("tcp", addr)
+		if err != nil {
+			t.Logf("re-listen: %v", err)
+			return
+		}
+		_ = srv.Serve(lis2)
+	}()
+	defer srv.GracefulStop()
+
+	if err := WaitForGRPC(ctx, log, addr); err != nil {
+		t.Fatalf("WaitForGRPC should succeed after delayed start: %v", err)
+	}
+}

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -20,6 +20,7 @@ import (
 	conf "github.com/k3d-io/k3d/v5/pkg/config/v1alpha5"
 	k3drt "github.com/k3d-io/k3d/v5/pkg/runtimes"
 	k3d "github.com/k3d-io/k3d/v5/pkg/types"
+	"k8s.io/client-go/rest"
 )
 
 // Options configures cluster creation.
@@ -159,47 +160,9 @@ func Create(ctx context.Context, log *zap.Logger, name string, opts Options) (*s
 		return nil, fmt.Errorf("building rest config: %w", err)
 	}
 
-	// Cilium values: base config + runtime overrides (node ports).
-	// k8sServiceHost is a placeholder here; cilium.Install detects the actual IP
-	// and it's already in the values passed to CreateApplications.
-	ciliumValues := infraconfig.MergeValues(cfg.CiliumValues, infraconfig.CiliumRuntimeOverrides(np, ""))
-
-	ciliumResult, err := cilium.Install(ctx, log, restCfg, name, cfg.Cilium, ciliumValues)
+	argocdResult, err := installInfra(ctx, log, restCfg, name, hp, cfg, gitopsDir)
 	if err != nil {
-		return nil, fmt.Errorf("installing cilium: %w", err)
-	}
-
-	// Update cilium values with the actual API server IP for the ArgoCD Application CRD.
-	ciliumValues = infraconfig.MergeValues(cfg.CiliumValues, infraconfig.CiliumRuntimeOverrides(np, ciliumResult.APIServerIP))
-
-	// ArgoCD values: base config + runtime overrides (node port).
-	argocdValues := infraconfig.MergeValues(cfg.ArgoCDValues, infraconfig.ArgoCDRuntimeOverrides(np))
-
-	argocdResult, err := argocd.Install(ctx, log, restCfg, cfg.ArgoCD, argocdValues)
-	if err != nil {
-		return nil, fmt.Errorf("installing argocd: %w", err)
-	}
-
-	if err := argocd.CreateApplications(ctx, log, restCfg, cfg.ArgoCD.Namespace,
-		argocd.AppParams{
-			Name: cfg.Cilium.ReleaseName, Namespace: cfg.Cilium.Namespace,
-			RepoURL: cfg.Cilium.RepoURL, ChartName: cfg.Cilium.Chart,
-			ChartVersion: ciliumResult.ChartVersion,
-			Values:       ciliumValues,
-		},
-		argocd.AppParams{
-			Name: cfg.ArgoCD.ReleaseName, Namespace: cfg.ArgoCD.Namespace,
-			RepoURL: cfg.ArgoCD.RepoURL, ChartName: cfg.ArgoCD.Chart,
-			ChartVersion: argocdResult.ChartVersion,
-			Values:       argocdValues,
-		},
-	); err != nil {
-		return nil, fmt.Errorf("creating argocd applications: %w", err)
-	}
-
-	// Apply root application from the scaffolded gitops repo.
-	if err := gitops.ApplyRootApp(ctx, log, restCfg, gitopsDir); err != nil {
-		return nil, fmt.Errorf("applying root application: %w", err)
+		return nil, err
 	}
 
 	// Build and save session.
@@ -235,6 +198,63 @@ func Create(ctx context.Context, log *zap.Logger, name string, opts Options) (*s
 
 	log.Info("k3d cluster created successfully", zap.String("cluster", name))
 	return sess, nil
+}
+
+// installInfra installs Cilium + ArgoCD, waits for gRPC readiness, creates
+// the initial Application CRDs, and applies the root ApplicationSet.
+func installInfra(ctx context.Context, log *zap.Logger, restCfg *rest.Config, name string, hp HostPorts, cfg *infraconfig.InfraConfig, gitopsDir string) (*argocd.InstallResult, error) {
+	np := cfg.Platform.NodePorts
+
+	// Cilium values: base config + runtime overrides (node ports).
+	ciliumValues := infraconfig.MergeValues(cfg.CiliumValues, infraconfig.CiliumRuntimeOverrides(np, ""))
+
+	ciliumResult, err := cilium.Install(ctx, log, restCfg, name, cfg.Cilium, ciliumValues)
+	if err != nil {
+		return nil, fmt.Errorf("installing cilium: %w", err)
+	}
+
+	// Update cilium values with the actual API server IP for the ArgoCD Application CRD.
+	ciliumValues = infraconfig.MergeValues(cfg.CiliumValues, infraconfig.CiliumRuntimeOverrides(np, ciliumResult.APIServerIP))
+
+	// ArgoCD values: base config + runtime overrides (node port).
+	argocdValues := infraconfig.MergeValues(cfg.ArgoCDValues, infraconfig.ArgoCDRuntimeOverrides(np))
+
+	argocdResult, err := argocd.Install(ctx, log, restCfg, cfg.ArgoCD, argocdValues)
+	if err != nil {
+		return nil, fmt.Errorf("installing argocd: %w", err)
+	}
+
+	// Wait for ArgoCD gRPC to be fully ready before creating Application CRDs.
+	// Deployment readiness probes pass before the gRPC listener and admission
+	// webhook are initialised, causing intermittent CreateApplications failures.
+	grpcAddr := fmt.Sprintf("localhost:%d", hp.ArgoCDGRPC)
+	if err := argocd.WaitForGRPC(ctx, log, grpcAddr); err != nil {
+		return nil, fmt.Errorf("waiting for argocd gRPC: %w", err)
+	}
+
+	if err := argocd.CreateApplications(ctx, log, restCfg, cfg.ArgoCD.Namespace,
+		argocd.AppParams{
+			Name: cfg.Cilium.ReleaseName, Namespace: cfg.Cilium.Namespace,
+			RepoURL: cfg.Cilium.RepoURL, ChartName: cfg.Cilium.Chart,
+			ChartVersion: ciliumResult.ChartVersion,
+			Values:       ciliumValues,
+		},
+		argocd.AppParams{
+			Name: cfg.ArgoCD.ReleaseName, Namespace: cfg.ArgoCD.Namespace,
+			RepoURL: cfg.ArgoCD.RepoURL, ChartName: cfg.ArgoCD.Chart,
+			ChartVersion: argocdResult.ChartVersion,
+			Values:       argocdValues,
+		},
+	); err != nil {
+		return nil, fmt.Errorf("creating argocd applications: %w", err)
+	}
+
+	// Apply root application from the scaffolded gitops repo.
+	if err := gitops.ApplyRootApp(ctx, log, restCfg, gitopsDir); err != nil {
+		return nil, fmt.Errorf("applying root application: %w", err)
+	}
+
+	return argocdResult, nil
 }
 
 // Delete deletes the k3d cluster with the given name and removes its kubeconfig entry.


### PR DESCRIPTION
## Summary

- Add `WaitForGRPC` that polls ArgoCD's unauthenticated `Version` endpoint (2s retry, 30s timeout) between `waitForDeployments` and `CreateApplications`, preventing intermittent webhook failures on slow hosts
- Extract `installInfra` helper from `Create` to keep cyclomatic complexity within lint thresholds
- Update progress tracker: T10 + T11 done (14/17)

## Test plan

- [x] `TestWaitForGRPC_Success` — fake Version server responds immediately
- [x] `TestWaitForGRPC_Timeout` — no server listening, probe times out
- [x] `TestWaitForGRPC_DelayedStart` — server starts after 2s delay, probe retries and succeeds
- [x] `make test` — all tests pass
- [x] `make lint` — 0 issues

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

**[Linus Torvalds Mode]**

Oh look, someone learned that Kubernetes readiness probes lie and decided to fix it by polling a gRPC endpoint — congratulations on discovering what the rest of us figured out the hard way three years ago. The code actually does what it says: this PR adds a `WaitForGRPC` probe that polls ArgoCD's unauthenticated `Version` endpoint (2 s retry, 30 s timeout) between `waitForDeployments` and `CreateApplications` to close the gap between pod readiness and application-level gRPC readiness, extracts an `installInfra` helper to tame cyclomatic complexity in `cluster.go`'s `Create`, and ships three tests covering success, timeout, and delayed-start scenarios.

The implementation is correct and the refactor is clean. Two residual issues from the prior review cycle remain open — the per-probe reconnect in `probeVersion` and the goroutine/`t.Logf` race in `TestWaitForGRPC_DelayedStart` — and have been addressed respectively by reusing the `apiclient.Client` across probes and routing goroutine errors through a buffered channel. What's left is trivial.

- `WaitForGRPC`: client is created once before the probe loop; `probeVersion` still opens a new `conn` per call via `NewVersionClient()` — still suboptimal but noted in prior review
- `TestWaitForGRPC_Timeout` uses hardcoded `127.0.0.1:1`; behavior is OS/firewall-dependent, the `:0`-listen-then-close idiom would be deterministic
- `WaitForGRPC` returns a hardcoded `"timed out waiting"` string on `ctx.Done()` regardless of whether the cause is deadline exceeded or user cancellation — wrapping `ctx.Err()` would be correct
- `installInfra` extraction is clean; session building correctly stays in `Create`; doc update is accurate

Even a mediocre engineer can ship this without it blowing up production.

<h3>Confidence Score: 4/5</h3>

**[Linus Torvalds Mode]** Two P2 style issues remain — a flaky test using port 1 and a misleading error string on context cancellation — and the per-probe reconnect from the prior review is still open; none of these will blow up production, so this thing is safe to merge if you can live with slightly dishonest error messages and a test that might flake on weird CI boxes.

I'm giving this a 4 instead of 5 only because the port-1 test flake is a real reliability concern in CI environments with strict firewall rules — it's the kind of thing that shows up as a spurious test failure on a Tuesday and wastes an hour. Everything else is P2 style. The core logic — gRPC probe insertion, client reuse, goroutine safety — is correct. Prior review concerns about the goroutine race were addressed. Would be a 5 if the test used the sane ephemeral-port idiom it already knows about.

install_test.go (port 1 flake) and install.go (ctx.Err() wrapping) deserve a second look before this gets copy-pasted into the next microservice.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/argocd/install.go | Adds WaitForGRPC + probeVersion: client reuse is correct, but ctx.Done() returns a misleading 'timed out' string on cancellation; per-probe NewVersionClient() connection cost is an open prior finding |
| internal/argocd/install_test.go | Three tests for WaitForGRPC; goroutine/t.Logf race from prior review addressed via listenErr channel; Timeout test uses fragile hardcoded port 1 instead of the ephemeral-port idiom already present in DelayedStart |
| internal/cluster/cluster.go | installInfra helper cleanly extracted from Create; WaitForGRPC correctly inserted between argocd.Install and CreateApplications; session building stays in Create; no issues |
| docs/superpowers/reports/2026-04-04-argocd-deployment-progress.md | Progress tracker updated: P4/T11 marked Done with correct PR reference, T10 cross-referenced, counts updated to 14/17; accurate |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Create as cluster.Create
    participant installInfra as installInfra (new)
    participant Cilium as cilium.Install
    participant ArgoCD as argocd.Install
    participant GRPC as argocd.WaitForGRPC
    participant Apps as argocd.CreateApplications
    participant Root as gitops.ApplyRootApp

    Create->>installInfra: ctx, restCfg, name, hp, cfg, gitopsDir
    installInfra->>Cilium: Install
    Cilium-->>installInfra: ciliumResult
    installInfra->>ArgoCD: Install (helm + waitForDeployments)
    ArgoCD-->>installInfra: argocdResult
    installInfra->>GRPC: WaitForGRPC(ctx, addr, 30s timeout)
    loop every 2s until ready or timeout
        GRPC->>GRPC: probeVersion → NewVersionClient → Version()
    end
    GRPC-->>installInfra: nil (ready)
    installInfra->>Apps: CreateApplications
    Apps-->>installInfra: ok
    installInfra->>Root: ApplyRootApp
    Root-->>installInfra: ok
    installInfra-->>Create: argocdResult
    Create->>Create: build & save session.Session
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/argocd/install_test.go
Line: 50

Comment:
**Hardcoded port 1 is a flaky trap**

This is the kind of "almost certainly" reasoning that bites you at 3 AM on a CI box with custom iptables rules. Congratulations on encoding an OS-dependent assumption directly into the test.

Port 1 (tcpmux) behavior varies: most kernels return `ECONNREFUSED` instantly, but firewalled environments silently drop the packet, making `probeVersion` hang until the context expires, and on exotic hosts something might actually be listening. `TestWaitForGRPC_DelayedStart` already uses the correct idiom — listen on `:0`, record the address, close immediately — giving a deterministic "nothing listening" address.

```suggestion
	lis, err := net.Listen("tcp", "127.0.0.1:0")
	if err != nil {
		t.Fatalf("listen for closed addr: %v", err)
	}
	addr := lis.Addr().String()
	_ = lis.Close()
```

You literally wrote the correct pattern two tests below this one and still didn't use it here.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/argocd/install.go
Line: 175-178

Comment:
**Misleading "timed out" on context cancel**

Imagine lying to the operator about why something failed — this code does exactly that. Burning a hardcoded string here instead of wrapping the actual cause is the diagnostic equivalent of a null pointer exception with no stack trace.

When the parent context is cancelled (user `ctrl-C`, test teardown, outer deadline) `ctx.Done()` fires and the function returns "timed out waiting" — which is factually wrong. Wrap `ctx.Err()` so the caller sees `context canceled` vs `context deadline exceeded` instead of a universal lie.

```suggestion
		case <-ctx.Done():
			return fmt.Errorf("waiting for ArgoCD gRPC at %s: %w", addr, ctx.Err())
```

One line. It was always one line.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: log probe errors in WaitForGRPC ret..."](https://github.com/sikifanso/sikifanso/commit/31b218077c9e2eeff58527252c95d84e8911c05c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27394522)</sub>

<!-- /greptile_comment -->