### PR TITLE
feat: sequence startup ApplicationSets to reduce resource contention

### DIFF
--- a/internal/argocd/healthcheck.go
+++ b/internal/argocd/healthcheck.go
@@ -1,0 +1,80 @@
+package argocd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+var (
+	appHealthTimeout  = 3 * time.Minute
+	appHealthInterval = 5 * time.Second
+)
+
+// WaitForApplicationsHealthy polls the named ArgoCD Applications until all
+// report Synced+Healthy, or the timeout expires. It uses the dynamic K8s
+// client to read Application CRD status directly — no ArgoCD gRPC dependency.
+func WaitForApplicationsHealthy(ctx context.Context, log *zap.Logger, restCfg *rest.Config, namespace string, names []string) error {
+	dc, err := dynamic.NewForConfig(restCfg)
+	if err != nil {
+		return fmt.Errorf("creating dynamic client: %w", err)
+	}
+
+	s := spinner.New(spinner.CharSets[11], 120*time.Millisecond, spinner.WithWriter(os.Stderr))
+	s.Suffix = " Waiting for infrastructure applications to be healthy..."
+	s.Start()
+	defer s.Stop()
+
+	ctx, cancel := context.WithTimeout(ctx, appHealthTimeout)
+	defer cancel()
+
+	log.Info("waiting for applications to be healthy", zap.Strings("apps", names))
+
+	for {
+		ready := 0
+		for _, name := range names {
+			synced, healthy, err := getAppStatus(ctx, dc, namespace, name)
+			if err != nil {
+				log.Debug("could not read application status", zap.String("app", name), zap.Error(err))
+				continue
+			}
+			if synced && healthy {
+				ready++
+			}
+		}
+
+		s.Suffix = fmt.Sprintf(" Waiting for infrastructure applications (%d/%d healthy)...", ready, len(names))
+
+		if ready == len(names) {
+			log.Info("all infrastructure applications are healthy")
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for applications to be healthy (%d/%d ready)", ready, len(names))
+		case <-time.After(appHealthInterval):
+		}
+	}
+}
+
+// getAppStatus reads the sync and health status of an ArgoCD Application CRD.
+func getAppStatus(ctx context.Context, dc dynamic.Interface, namespace, name string) (synced, healthy bool, err error) {
+	obj, err := dc.Resource(applicationGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return false, false, err
+	}
+
+	syncStatus, _, _ := unstructured.NestedString(obj.Object, "status", "sync", "status")
+	healthStatus, _, _ := unstructured.NestedString(obj.Object, "status", "health", "status")
+
+	return syncStatus == "Synced", healthStatus == "Healthy", nil
+}

--- a/internal/argocd/healthcheck.go
+++ b/internal/argocd/healthcheck.go
@@ -22,21 +22,22 @@ var (
 // WaitForApplicationsHealthy polls the named ArgoCD Applications until all
 // report Synced+Healthy, or the timeout expires. It uses the dynamic K8s
 // client to read Application CRD status directly — no ArgoCD gRPC dependency.
-func WaitForApplicationsHealthy(ctx context.Context, log *zap.Logger, restCfg *rest.Config, namespace string, names []string) error {
+// The label is used in spinner and log messages (e.g. "infrastructure").
+func WaitForApplicationsHealthy(ctx context.Context, log *zap.Logger, restCfg *rest.Config, namespace string, names []string, label string) error {
 	dc, err := dynamic.NewForConfig(restCfg)
 	if err != nil {
 		return fmt.Errorf("creating dynamic client: %w", err)
 	}
 
 	s := spinner.New(spinner.CharSets[11], 120*time.Millisecond, spinner.WithWriter(os.Stderr))
-	s.Suffix = " Waiting for infrastructure applications to be healthy..."
+	s.Suffix = fmt.Sprintf(" Waiting for %s applications to be healthy...", label)
 	s.Start()
 	defer s.Stop()
 
 	ctx, cancel := context.WithTimeout(ctx, appHealthTimeout)
 	defer cancel()
 
-	log.Info("waiting for applications to be healthy", zap.Strings("apps", names))
+	log.Info("waiting for applications to be healthy", zap.String("label", label), zap.Strings("apps", names))
 
 	for {
 		ready := 0
@@ -51,16 +52,19 @@ func WaitForApplicationsHealthy(ctx context.Context, log *zap.Logger, restCfg *r
 			}
 		}
 
-		s.Suffix = fmt.Sprintf(" Waiting for infrastructure applications (%d/%d healthy)...", ready, len(names))
+		s.Suffix = fmt.Sprintf(" Waiting for %s applications (%d/%d healthy)...", label, ready, len(names))
 
 		if ready == len(names) {
-			log.Info("all infrastructure applications are healthy")
+			log.Info("all applications are healthy", zap.String("label", label))
 			return nil
 		}
 
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("timed out waiting for applications to be healthy (%d/%d ready)", ready, len(names))
+			if ctx.Err() == context.DeadlineExceeded {
+				return fmt.Errorf("timed out waiting for %s applications to be healthy (%d/%d ready)", label, ready, len(names))
+			}
+			return fmt.Errorf("cancelled waiting for %s applications to be healthy (%d/%d ready)", label, ready, len(names))
 		case <-time.After(appHealthInterval):
 		}
 	}

--- a/internal/argocd/healthcheck_test.go
+++ b/internal/argocd/healthcheck_test.go
@@ -134,7 +134,7 @@ func TestWaitForApplicationsHealthy_AlreadyHealthy(t *testing.T) {
 	restCfg := &rest.Config{Host: "http://" + ln.Addr().String()}
 	log := zaptest.NewLogger(t)
 
-	err = WaitForApplicationsHealthy(context.Background(), log, restCfg, "argocd", []string{"cilium", "argo-cd"})
+	err = WaitForApplicationsHealthy(context.Background(), log, restCfg, "argocd", []string{"cilium", "argo-cd"}, "infrastructure")
 	if err != nil {
 		t.Fatalf("expected success: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestWaitForApplicationsHealthy_Timeout(t *testing.T) {
 	restCfg := &rest.Config{Host: "http://" + ln.Addr().String()}
 	log := zaptest.NewLogger(t)
 
-	err = WaitForApplicationsHealthy(context.Background(), log, restCfg, "argocd", []string{"cilium"})
+	err = WaitForApplicationsHealthy(context.Background(), log, restCfg, "argocd", []string{"cilium"}, "infrastructure")
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}

--- a/internal/argocd/healthcheck_test.go
+++ b/internal/argocd/healthcheck_test.go
@@ -1,0 +1,180 @@
+package argocd
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"go.uber.org/zap/zaptest"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/rest"
+)
+
+func fakeApp(name, syncStatus, healthStatus string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Application",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": "argocd",
+			},
+			"status": map[string]interface{}{
+				"sync": map[string]interface{}{
+					"status": syncStatus,
+				},
+				"health": map[string]interface{}{
+					"status": healthStatus,
+				},
+			},
+		},
+	}
+}
+
+func TestGetAppStatus_SyncedHealthy(t *testing.T) {
+	scheme := runtime.NewScheme()
+	dc := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			applicationGVR: "ApplicationList",
+		},
+		fakeApp("cilium", "Synced", "Healthy"),
+	)
+
+	synced, healthy, err := getAppStatus(context.Background(), dc, "argocd", "cilium")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !synced || !healthy {
+		t.Fatalf("expected synced=true healthy=true, got synced=%v healthy=%v", synced, healthy)
+	}
+}
+
+func TestGetAppStatus_Progressing(t *testing.T) {
+	scheme := runtime.NewScheme()
+	dc := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			applicationGVR: "ApplicationList",
+		},
+		fakeApp("cilium", "OutOfSync", "Progressing"),
+	)
+
+	synced, healthy, err := getAppStatus(context.Background(), dc, "argocd", "cilium")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if synced || healthy {
+		t.Fatalf("expected synced=false healthy=false, got synced=%v healthy=%v", synced, healthy)
+	}
+}
+
+func TestGetAppStatus_NotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	dc := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			applicationGVR: "ApplicationList",
+		},
+	)
+
+	_, _, err := getAppStatus(context.Background(), dc, "argocd", "missing")
+	if err == nil {
+		t.Fatal("expected error for missing app")
+	}
+}
+
+func TestWaitForApplicationsHealthy_AlreadyHealthy(t *testing.T) {
+	origTimeout := appHealthTimeout
+	origInterval := appHealthInterval
+	appHealthTimeout = 5 * time.Second
+	appHealthInterval = 100 * time.Millisecond
+	defer func() {
+		appHealthTimeout = origTimeout
+		appHealthInterval = origInterval
+	}()
+
+	// We cannot use WaitForApplicationsHealthy directly because it creates
+	// a dynamic client from rest.Config. Instead, test the polling logic
+	// via a local HTTP test server that serves the K8s API.
+	// For unit testing, we validate getAppStatus above and do an integration-style
+	// test here with a fake REST server.
+
+	// Start a minimal fake API server that returns healthy apps.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/apis/argoproj.io/v1alpha1/namespaces/argocd/applications/cilium", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind": "Application",
+			"metadata": {"name": "cilium", "namespace": "argocd"},
+			"status": {"sync": {"status": "Synced"}, "health": {"status": "Healthy"}}
+		}`))
+	})
+	mux.HandleFunc("/apis/argoproj.io/v1alpha1/namespaces/argocd/applications/argo-cd", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind": "Application",
+			"metadata": {"name": "argo-cd", "namespace": "argocd"},
+			"status": {"sync": {"status": "Synced"}, "health": {"status": "Healthy"}}
+		}`))
+	})
+
+	srv := &http.Server{Addr: "127.0.0.1:0", Handler: mux}
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	restCfg := &rest.Config{Host: "http://" + ln.Addr().String()}
+	log := zaptest.NewLogger(t)
+
+	err = WaitForApplicationsHealthy(context.Background(), log, restCfg, "argocd", []string{"cilium", "argo-cd"})
+	if err != nil {
+		t.Fatalf("expected success: %v", err)
+	}
+}
+
+func TestWaitForApplicationsHealthy_Timeout(t *testing.T) {
+	origTimeout := appHealthTimeout
+	origInterval := appHealthInterval
+	appHealthTimeout = 2 * time.Second
+	appHealthInterval = 100 * time.Millisecond
+	defer func() {
+		appHealthTimeout = origTimeout
+		appHealthInterval = origInterval
+	}()
+
+	// Server always returns Progressing.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/apis/argoproj.io/v1alpha1/namespaces/argocd/applications/cilium", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind": "Application",
+			"metadata": {"name": "cilium", "namespace": "argocd"},
+			"status": {"sync": {"status": "OutOfSync"}, "health": {"status": "Progressing"}}
+		}`))
+	})
+
+	srv := &http.Server{Addr: "127.0.0.1:0", Handler: mux}
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	restCfg := &rest.Config{Host: "http://" + ln.Addr().String()}
+	log := zaptest.NewLogger(t)
+
+	err = WaitForApplicationsHealthy(context.Background(), log, restCfg, "argocd", []string{"cilium"})
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+}

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -232,26 +232,40 @@ func installInfra(ctx context.Context, log *zap.Logger, restCfg *rest.Config, na
 		return nil, fmt.Errorf("waiting for argocd gRPC: %w", err)
 	}
 
-	if err := argocd.CreateApplications(ctx, log, restCfg, cfg.ArgoCD.Namespace,
-		argocd.AppParams{
+	infraApps := []argocd.AppParams{
+		{
 			Name: cfg.Cilium.ReleaseName, Namespace: cfg.Cilium.Namespace,
 			RepoURL: cfg.Cilium.RepoURL, ChartName: cfg.Cilium.Chart,
 			ChartVersion: ciliumResult.ChartVersion,
 			Values:       ciliumValues,
 		},
-		argocd.AppParams{
+		{
 			Name: cfg.ArgoCD.ReleaseName, Namespace: cfg.ArgoCD.Namespace,
 			RepoURL: cfg.ArgoCD.RepoURL, ChartName: cfg.ArgoCD.Chart,
 			ChartVersion: argocdResult.ChartVersion,
 			Values:       argocdValues,
 		},
-	); err != nil {
+	}
+
+	if err := argocd.CreateApplications(ctx, log, restCfg, cfg.ArgoCD.Namespace, infraApps...); err != nil {
 		return nil, fmt.Errorf("creating argocd applications: %w", err)
 	}
 
-	// Apply root application from the scaffolded gitops repo.
-	if err := gitops.ApplyRootApp(ctx, log, restCfg, gitopsDir); err != nil {
-		return nil, fmt.Errorf("applying root application: %w", err)
+	// Apply the infrastructure ApplicationSet first — Cilium and ArgoCD must be
+	// healthy before workload ApplicationSets start, to avoid resource contention
+	// on constrained hosts.
+	if err := gitops.ApplyInfraManifests(ctx, log, restCfg, gitopsDir); err != nil {
+		return nil, fmt.Errorf("applying infrastructure applicationset: %w", err)
+	}
+
+	if err := argocd.WaitForApplicationsHealthy(ctx, log, restCfg, cfg.ArgoCD.Namespace,
+		[]string{cfg.Cilium.ReleaseName, cfg.ArgoCD.ReleaseName}); err != nil {
+		return nil, fmt.Errorf("waiting for infrastructure applications: %w", err)
+	}
+
+	// Catalog and agent ApplicationSets depend on CRDs and webhooks from the infra phase.
+	if err := gitops.ApplyWorkloadManifests(ctx, log, restCfg, gitopsDir); err != nil {
+		return nil, fmt.Errorf("applying workload applicationsets: %w", err)
 	}
 
 	return argocdResult, nil

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -259,7 +259,7 @@ func installInfra(ctx context.Context, log *zap.Logger, restCfg *rest.Config, na
 	}
 
 	if err := argocd.WaitForApplicationsHealthy(ctx, log, restCfg, cfg.ArgoCD.Namespace,
-		[]string{cfg.Cilium.ReleaseName, cfg.ArgoCD.ReleaseName}); err != nil {
+		[]string{cfg.Cilium.ReleaseName, cfg.ArgoCD.ReleaseName}, "infrastructure"); err != nil {
 		return nil, fmt.Errorf("waiting for infrastructure applications: %w", err)
 	}
 

--- a/internal/gitops/rootapp.go
+++ b/internal/gitops/rootapp.go
@@ -32,15 +32,6 @@ var workloadManifests = []string{
 	"bootstrap/root-agents.yaml",
 }
 
-// ApplyRootApp reads the bootstrap ApplicationSet manifests from the gitops
-// directory and applies them to the cluster via Server-Side Apply.
-func ApplyRootApp(ctx context.Context, log *zap.Logger, restCfg *rest.Config, gitopsDir string) error {
-	manifests := make([]string, 0, len(infraManifests)+len(workloadManifests))
-	manifests = append(manifests, infraManifests...)
-	manifests = append(manifests, workloadManifests...)
-	return applyManifests(ctx, log, restCfg, gitopsDir, manifests)
-}
-
 // ApplyInfraManifests applies only the infrastructure ApplicationSet
 // (root-app.yaml) that manages Cilium and ArgoCD.
 func ApplyInfraManifests(ctx context.Context, log *zap.Logger, restCfg *rest.Config, gitopsDir string) error {

--- a/internal/gitops/rootapp.go
+++ b/internal/gitops/rootapp.go
@@ -20,9 +20,14 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// bootstrapManifests lists the manifests that ApplyRootApp applies to the cluster.
-var bootstrapManifests = []string{
+// infraManifests are applied first — they manage core platform apps
+// (Cilium, ArgoCD) that must be healthy before workloads start.
+var infraManifests = []string{
 	"bootstrap/root-app.yaml",
+}
+
+// workloadManifests are applied after infrastructure apps are healthy.
+var workloadManifests = []string{
 	"bootstrap/root-catalog.yaml",
 	"bootstrap/root-agents.yaml",
 }
@@ -30,6 +35,24 @@ var bootstrapManifests = []string{
 // ApplyRootApp reads the bootstrap ApplicationSet manifests from the gitops
 // directory and applies them to the cluster via Server-Side Apply.
 func ApplyRootApp(ctx context.Context, log *zap.Logger, restCfg *rest.Config, gitopsDir string) error {
+	manifests := make([]string, 0, len(infraManifests)+len(workloadManifests))
+	manifests = append(manifests, infraManifests...)
+	manifests = append(manifests, workloadManifests...)
+	return applyManifests(ctx, log, restCfg, gitopsDir, manifests)
+}
+
+// ApplyInfraManifests applies only the infrastructure ApplicationSet
+// (root-app.yaml) that manages Cilium and ArgoCD.
+func ApplyInfraManifests(ctx context.Context, log *zap.Logger, restCfg *rest.Config, gitopsDir string) error {
+	return applyManifests(ctx, log, restCfg, gitopsDir, infraManifests)
+}
+
+// ApplyWorkloadManifests applies the catalog and agent ApplicationSets.
+func ApplyWorkloadManifests(ctx context.Context, log *zap.Logger, restCfg *rest.Config, gitopsDir string) error {
+	return applyManifests(ctx, log, restCfg, gitopsDir, workloadManifests)
+}
+
+func applyManifests(ctx context.Context, log *zap.Logger, restCfg *rest.Config, gitopsDir string, manifests []string) error {
 	dc, err := dynamic.NewForConfig(restCfg)
 	if err != nil {
 		return fmt.Errorf("creating dynamic client: %w", err)
@@ -41,7 +64,7 @@ func ApplyRootApp(ctx context.Context, log *zap.Logger, restCfg *rest.Config, gi
 	}
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(disc))
 
-	for _, rel := range bootstrapManifests {
+	for _, rel := range manifests {
 		if err := applyManifest(ctx, log, dc, mapper, filepath.Join(gitopsDir, rel)); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
- Split bootstrap into two phases during `cluster create`: apply the infrastructure ApplicationSet (`root-app.yaml`) first, wait for Cilium and ArgoCD to reach `Synced+Healthy`, then apply catalog and agent ApplicationSets
- Add `WaitForApplicationsHealthy` which polls Application CRD status via the dynamic K8s client — no gRPC dependency
- Refactor `gitops.ApplyRootApp` into `ApplyInfraManifests` / `ApplyWorkloadManifests` with shared `applyManifests` helper

Refs: T12, P17

## Test plan
- [x] Unit tests for `getAppStatus` (Synced+Healthy, Progressing, NotFound)
- [x] Integration tests for `WaitForApplicationsHealthy` (already healthy, timeout)
- [x] Full test suite passes (`make test`)
- [x] Lint clean (`make lint`)
- [ ] Manual: `cluster create` on constrained host shows Cilium healthy before catalog apps start syncing

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

**[Linus Torvalds Mode]** Oh look, someone discovered that dumping every ApplicationSet at once on a constrained host causes resource chaos and decided to fix it — congratulations on reinventing sequencing, a concept older than half the people reviewing this. The actual implementation is mostly reasonable: this PR splits the bootstrap path in `cluster.go` into two phases (infra ApplicationSet first, wait for Cilium + ArgoCD `Synced+Healthy`, then workload ApplicationSets), adds a `WaitForApplicationsHealthy` poller via the dynamic K8s client with no gRPC dependency, and refactors `ApplyRootApp` into `ApplyInfraManifests` / `ApplyWorkloadManifests` with a shared `applyManifests` helper.

- `installInfra` in `cluster.go` correctly sequences: apply infra → poll for Synced+Healthy → apply workloads
- `WaitForApplicationsHealthy` correctly uses the `label` parameter for spinner text and log messages (prior comment addressed)
- Tests cover Synced+Healthy, Progressing, NotFound, and timeout paths
- `applyManifest` in `rootapp.go` unconditionally calls `.Namespace(ns).Patch()` without checking `mapping.Scope.Name()` — silently broken for any cluster-scoped resource added to either manifest list in the future

You'd think someone writing infrastructure bootstrap code would handle the basic "is this cluster-scoped?" check before calling `.Namespace()`, but here we are.

<h3>Confidence Score: 4/5</h3>

**[Linus Torvalds Mode]** Someone finally sequenced the bootstrap instead of just praying everything comes up in the right order — colour me mildly impressed. The core logic is sound and mostly safe to merge, but there is a latent cluster-scoped resource bug in `applyManifest` that will silently construct the wrong API URL the moment anyone adds a non-namespaced manifest to either list.

Unbelievable that a two-phase sequencing PR ships with an unconditional `.Namespace()` call that breaks for any cluster-scoped resource — 'works on my ApplicationSets' is not engineering. The sequencing logic in `cluster.go` is correct, `WaitForApplicationsHealthy` is functional, and the tests are adequate. The remaining P2 finding describes a real correctness issue (wrong API path for cluster-scoped resources) even if it only fires when manifests change, so this lands at 4 rather than 5. At least the `ApplyRootApp` dead code got cleaned up this time.

Stare at `internal/gitops/rootapp.go` — specifically the `applyManifest` function and its cheerful assumption that every bootstrap resource has a namespace.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/argocd/healthcheck.go | New WaitForApplicationsHealthy poller using dynamic client; label param and spinner text now correct; 3-minute timeout may be too short for constrained hosts (flagged in prior review) |
| internal/argocd/healthcheck_test.go | Unit + integration-style tests for getAppStatus and WaitForApplicationsHealthy covering Synced+Healthy, Progressing, NotFound, and timeout paths; no parallel-safety issues |
| internal/cluster/cluster.go | installInfra correctly sequences: apply infra ApplicationSet → wait Synced+Healthy → apply workload ApplicationSets; sequencing logic is sound |
| internal/gitops/rootapp.go | ApplyRootApp refactored into ApplyInfraManifests/ApplyWorkloadManifests with shared helper; applyManifest unconditionally calls .Namespace() without checking REST scope — latent bug for cluster-scoped resources |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI
    participant cluster.installInfra
    participant cilium.Install
    participant argocd.Install
    participant argocd.WaitForGRPC
    participant argocd.CreateApplications
    participant gitops.ApplyInfraManifests
    participant argocd.WaitForApplicationsHealthy
    participant gitops.ApplyWorkloadManifests

    CLI->>cluster.installInfra: Create(ctx, name, opts)
    cluster.installInfra->>cilium.Install: Install(ctx, ...)
    cluster.installInfra->>argocd.Install: Install(ctx, ...)
    cluster.installInfra->>argocd.WaitForGRPC: WaitForGRPC(ctx, grpcAddr)
    cluster.installInfra->>argocd.CreateApplications: CreateApplications(cilium, argocd)
    cluster.installInfra->>gitops.ApplyInfraManifests: SSA patch root-app.yaml
    loop Poll every 5s (max 3 min)
        argocd.WaitForApplicationsHealthy->>argocd.WaitForApplicationsHealthy: getAppStatus(cilium, argo-cd)
        argocd.WaitForApplicationsHealthy-->>cluster.installInfra: all Synced+Healthy / timeout error
    end
    cluster.installInfra->>gitops.ApplyWorkloadManifests: SSA patch root-catalog.yaml, root-agents.yaml
    cluster.installInfra-->>CLI: Session
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/gitops/rootapp.go
Line: 79-113

Comment:
**Cluster-scoped resources will get wrong API path**

What a creative way to silently misroute any cluster-scoped resource that dares appear in these manifest lists. This is infrastructure glue that works fine right up until someone adds a `ClusterRole` and spends two hours debugging a 404.

`applyManifest` always calls `.Namespace(ns).Patch(...)` regardless of REST scope. For cluster-scoped resources (`mapping.Scope.Name() == meta.RESTScopeNameRoot`), the namespace segment in the URL is invalid — the API server will reject or misroute the request. The current manifests are all namespace-scoped `ApplicationSet` objects so this passes today, but it is a silent landmine for any future `ClusterRole` or `CRD` added to either list. Check the scope before selecting the client path:

```go
var resourceClient dynamic.ResourceInterface
if mapping.Scope.Name() == meta.RESTScopeNameRoot {
    resourceClient = dc.Resource(mapping.Resource)
} else {
    resourceClient = dc.Resource(mapping.Resource).Namespace(ns)
}

_, err = resourceClient.Patch(
    ctx,
    obj.GetName(),
    types.ApplyPatchType,
    jsonData,
    metav1.PatchOptions{
        FieldManager: "sikifanso",
        Force:        ptr.To(true),
    },
)
```

You've labelled this trap 'works on my manifests' and left it sitting right in the middle of the bootstrap path.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address PR review comments"](https://github.com/sikifanso/sikifanso/commit/eafc84ceccb1adc20470bde6a5ed609f29b94397) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27398684)</sub>

<!-- /greptile_comment -->