### PR TITLE
fix: embed per-app diagnostics in sync error messages

### DIFF
--- a/cmd/sikifanso/app_sync.go
+++ b/cmd/sikifanso/app_sync.go
@@ -60,9 +60,9 @@ func appSyncCmd() *cli.Command {
 
 			switch exitCode {
 			case grpcsync.ExitFailure:
-				return fmt.Errorf("sync failed: one or more apps unhealthy")
+				return fmt.Errorf("sync failed: %s", summarizeUnhealthy(results))
 			case grpcsync.ExitTimeout:
-				return fmt.Errorf("sync timed out: apps still progressing")
+				return fmt.Errorf("sync timed out: %s (try a longer --timeout)", summarizeUnhealthy(results))
 			}
 			return nil
 		}),

--- a/cmd/sikifanso/middleware.go
+++ b/cmd/sikifanso/middleware.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -144,12 +145,12 @@ func syncAfterMutation(ctx context.Context, cmd *cli.Command, sess *session.Sess
 		if opts.Operation == grpcsync.OpDisable {
 			return fmt.Errorf("disable incomplete: Application deletion still in progress (resources may have long termination grace periods — try a longer --timeout)")
 		}
-		return fmt.Errorf("sync failed: one or more apps unhealthy")
+		return fmt.Errorf("sync failed: %s", summarizeUnhealthy(results))
 	case grpcsync.ExitTimeout:
 		if opts.Operation == grpcsync.OpDisable {
 			return fmt.Errorf("disable timed out: Application deletion still in progress (try --timeout 10m)")
 		}
-		return fmt.Errorf("sync timed out: apps may still be reconciling (try a longer --timeout)")
+		return fmt.Errorf("sync timed out: %s (try a longer --timeout)", summarizeUnhealthy(results))
 	}
 	return nil
 }
@@ -182,6 +183,30 @@ func printSyncResults(w io.Writer, results []grpcsync.Result) {
 			}
 		}
 	}
+}
+
+// summarizeUnhealthy builds a one-line summary of apps that are not Synced+Healthy,
+// including the first degraded resource message per app for actionable diagnostics.
+func summarizeUnhealthy(results []grpcsync.Result) string {
+	var parts []string
+	for _, r := range results {
+		if r.Deleted || (r.SyncStatus == "Synced" && r.Health == "Healthy") {
+			continue
+		}
+		detail := fmt.Sprintf("%s (sync=%s health=%s)", r.App, r.SyncStatus, r.Health)
+		// Only the first unhealthy resource — keep the error line scannable.
+		for _, res := range r.Resources {
+			if res.Health != "" && res.Health != "Healthy" && res.Message != "" {
+				detail += fmt.Sprintf(" [%s/%s: %s]", res.Kind, res.Name, res.Message)
+				break
+			}
+		}
+		parts = append(parts, detail)
+	}
+	if len(parts) == 0 {
+		return "one or more apps unhealthy"
+	}
+	return strings.Join(parts, "; ")
 }
 
 // buildAppTiers returns a map of app name → tier for tier-aware sequencing.

--- a/cmd/sikifanso/middleware.go
+++ b/cmd/sikifanso/middleware.go
@@ -194,7 +194,7 @@ func summarizeUnhealthy(results []grpcsync.Result) string {
 			continue
 		}
 		detail := fmt.Sprintf("%s (sync=%s health=%s)", r.App, r.SyncStatus, r.Health)
-		// Only the first unhealthy resource — keep the error line scannable.
+		// First unhealthy resource with a non-empty message — keeps the error line scannable.
 		for _, res := range r.Resources {
 			if res.Health != "" && res.Health != "Healthy" && res.Message != "" {
 				detail += fmt.Sprintf(" [%s/%s: %s]", res.Kind, res.Name, res.Message)

--- a/cmd/sikifanso/middleware_test.go
+++ b/cmd/sikifanso/middleware_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/alicanalbayrak/sikifanso/internal/argocd/grpcclient"
+	"github.com/alicanalbayrak/sikifanso/internal/argocd/grpcsync"
+)
+
+func TestSummarizeUnhealthy(t *testing.T) {
+	tests := []struct {
+		name    string
+		results []grpcsync.Result
+		want    string
+	}{
+		{
+			name:    "all healthy returns fallback",
+			results: []grpcsync.Result{{App: "a", SyncStatus: "Synced", Health: "Healthy"}},
+			want:    "one or more apps unhealthy",
+		},
+		{
+			name:    "empty results returns fallback",
+			results: nil,
+			want:    "one or more apps unhealthy",
+		},
+		{
+			name: "single degraded app",
+			results: []grpcsync.Result{
+				{App: "langfuse", SyncStatus: "Synced", Health: "Degraded"},
+			},
+			want: "langfuse (sync=Synced health=Degraded)",
+		},
+		{
+			name: "degraded app with resource message",
+			results: []grpcsync.Result{
+				{
+					App: "langfuse", SyncStatus: "Synced", Health: "Degraded",
+					Resources: []grpcclient.ResourceStatus{
+						{Kind: "Deployment", Name: "langfuse-web", Health: "Degraded", Message: "CrashLoopBackOff"},
+					},
+				},
+			},
+			want: "langfuse (sync=Synced health=Degraded) [Deployment/langfuse-web: CrashLoopBackOff]",
+		},
+		{
+			name: "multiple unhealthy apps",
+			results: []grpcsync.Result{
+				{App: "valkey", SyncStatus: "Synced", Health: "Healthy"},
+				{App: "langfuse", SyncStatus: "OutOfSync", Health: "Progressing"},
+				{App: "presidio", SyncStatus: "Synced", Health: "Degraded"},
+			},
+			want: "langfuse (sync=OutOfSync health=Progressing); presidio (sync=Synced health=Degraded)",
+		},
+		{
+			name: "deleted apps excluded",
+			results: []grpcsync.Result{
+				{App: "langfuse", Deleted: true},
+				{App: "presidio", SyncStatus: "Synced", Health: "Missing"},
+			},
+			want: "presidio (sync=Synced health=Missing)",
+		},
+		{
+			name: "only first degraded resource included",
+			results: []grpcsync.Result{
+				{
+					App: "langfuse", SyncStatus: "Synced", Health: "Degraded",
+					Resources: []grpcclient.ResourceStatus{
+						{Kind: "Deployment", Name: "web", Health: "Degraded", Message: "CrashLoopBackOff"},
+						{Kind: "Deployment", Name: "worker", Health: "Degraded", Message: "OOMKilled"},
+					},
+				},
+			},
+			want: "langfuse (sync=Synced health=Degraded) [Deployment/web: CrashLoopBackOff]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := summarizeUnhealthy(tt.results)
+			if got != tt.want {
+				t.Errorf("summarizeUnhealthy() =\n  %q\nwant:\n  %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/superpowers/reports/2026-04-04-argocd-deployment-progress.md
+++ b/docs/superpowers/reports/2026-04-04-argocd-deployment-progress.md
@@ -26,7 +26,7 @@
 | P14 | Medium | Default branch conflates Progressing and Unknown | Open | |
 | P15 | Medium | Spinner suffix data race under concurrent watches | Open | |
 | P16 | Medium | ReconcileFn error swallowed, causes full-timeout block | Open | |
-| P17 | Medium | Root ApplicationSets start concurrently — resource contention | Open | |
+| P17 | Medium | Root ApplicationSets start concurrently — resource contention | **Done** | PR #15 — phased bootstrap: infra AppSet → health gate → workload AppSets |
 | P18 | Medium | ResourceTree misses sync error messages | Open | |
 | P19 | Medium | gRPC connection has no keep-alive | Open | |
 | P20 | Medium | agent-full exceeds safe memory for 8-16 GiB hosts | Open | |
@@ -53,7 +53,7 @@
 | T9 | Medium | Replace pollOnce with retry loop | **Done** | P10 |
 | T10 | Medium | Tier-aware watchApps goroutine sequencing | **Done** | P6 — PR #13; tier-aware sequencing + reverse order for disable |
 | T11 | Medium | ArgoCD gRPC readiness probe after install | **Done** | P4 — WaitForGRPC polls Version endpoint; installInfra extracted from Create |
-| T12 | Medium | Startup ApplicationSet sequencing in cluster create | Open | P17 |
+| T12 | Medium | Startup ApplicationSet sequencing in cluster create | **Done** | P17 — PR #15; phased bootstrap with WaitForApplicationsHealthy |
 | T13 | Medium | Actionable error messages from Result slice | Open | P13 |
 | T14 | Medium | Fix spinner data race + multi-app progress | Open | P15 |
 | T15 | Medium | Temporal per-service resources + disable Elasticsearch | Open | P21 |
@@ -64,7 +64,7 @@
 
 ## Summary
 
-- **Completed**: 14/17 tasks (T1–T11 + associated review fixes)
+- **Completed**: 15/17 tasks (T1–T12 + associated review fixes)
 - **Remaining Critical**: 0
 - **Remaining High**: 0
 - **Remaining Medium**: 6 (T12–T17)


### PR DESCRIPTION
## Summary

- Replace static `"one or more apps unhealthy"` / `"apps still progressing"` error messages with per-app diagnostics from the `grpcsync.Result` slice
- New `summarizeUnhealthy()` builds a one-line summary: app name, sync/health status, and first degraded resource message
- Applied to both `syncAfterMutation` (enable/disable/add/remove) and `app sync` command
- 7 table-driven tests covering: all healthy, empty results, single degraded, degraded with resource message, multiple unhealthy, deleted exclusion, first-resource-only

**Before:**
```
sync failed: one or more apps unhealthy
```

**After:**
```
sync failed: langfuse (sync=Synced health=Degraded) [Deployment/langfuse-web: CrashLoopBackOff]
```

## Test plan

- [ ] `go test ./cmd/sikifanso/ -run TestSummarizeUnhealthy -race` — all 7 cases pass
- [ ] `make test` — full suite green
- [ ] `make lint` — zero issues
- [ ] Manual: `sikifanso catalog enable` an app with misconfigured values → verify error includes app name + status

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

**[Linus Torvalds Mode]**

Congratulations, someone finally figured out that "one or more apps unhealthy" is the most useless error message since "an error occurred." This whole PR exists because nobody bothered to embed the actual diagnostic information the orchestrator already had sitting in the `Result` slice.

This PR replaces the static `"one or more apps unhealthy"` / `"apps still progressing"` error strings with a new `summarizeUnhealthy()` helper that builds a one-line diagnostic per unhealthy app — including name, sync/health status, and the first degraded resource with a non-empty message. The change is applied consistently to both `syncAfterMutation` (enable/disable/add/remove paths in `middleware.go`) and the explicit `app sync` command (`app_sync.go`). The `OpDisable` path retains its hardcoded message for app-deletion-in-progress scenarios, which is correct. Seven table-driven tests cover the main cases. The only gap is the missing test for the message-less-resource-skip path: the loop guard `res.Message != ""` means a degraded resource with an empty message is skipped in favour of the next one that has a message — this branching is described in the inline comment but is not exercised by any test case.

- `summarizeUnhealthy()` correctly excludes deleted apps and apps in `Synced+Healthy` state
- Fallback to `"one or more apps unhealthy"` is preserved when no unhealthy apps surface (e.g. all results deleted), which is a safe defensive path
- Both `ExitFailure` and `ExitTimeout` now carry per-app diagnostics in the error string
- Test suite covers all-healthy, empty, single degraded, resource-message, multi-unhealthy, deleted-exclusion, and first-resource-only cases

Safe to merge — but whoever wrote those seven tests and forgot the eighth one should be mildly embarrassed.

<h3>Confidence Score: 5/5</h3>

**[Linus Torvalds Mode]** The bar for this PR was 'replace a useless string with a useful one' and it mostly cleared it — safe to merge, the only thing broken is one missing test case that someone will definitely forget to add later.

Did you seriously write seven tests and miss the one case the comment literally describes? Remarkable. Technically, there are zero P0 or P1 findings: the logic in summarizeUnhealthy is correct, OpDisable is guarded properly in syncAfterMutation, the fallback path is safe, and the change is applied consistently to both call sites. The only finding is a P2 test gap for the message-less resource skip path. Score is 5 — P2-only findings do not block merge, and a missing test edge case doesn't constitute a correctness defect. At least someone finally put the diagnostic information in the error message where it belongs, rather than burying it in log output nobody reads.

middleware_test.go — seven tests that don't cover the one branching behavior explicitly documented in the code; please embarrass yourself slightly less by adding the eighth case

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/sikifanso/middleware.go | Adds summarizeUnhealthy() to embed per-app diagnostics in sync error messages; correctly plumbed into syncAfterMutation for both ExitFailure and ExitTimeout with OpDisable guard intact |
| cmd/sikifanso/app_sync.go | Applies summarizeUnhealthy() to appSyncCmd ExitFailure/ExitTimeout paths; mirrors middleware.go change cleanly |
| cmd/sikifanso/middleware_test.go | 7 table-driven tests for summarizeUnhealthy(); missing coverage for message-less degraded resource skip path described in middleware.go line 197 comment |
| docs/superpowers/reports/2026-04-04-argocd-deployment-progress.md | Documentation report only; no code changes to review |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SyncAndWait returns] --> B{exitCode}
    B -->|ExitSuccess| C[return nil]
    B -->|ExitFailure| D{OpDisable?}
    B -->|ExitTimeout| E{OpDisable?}
    D -->|yes| F[return hardcoded deletion-in-progress error]
    D -->|no| G[summarizeUnhealthy results]
    E -->|yes| H[return hardcoded timeout deletion error]
    E -->|no| I[summarizeUnhealthy results]
    G --> J{any unhealthy parts?}
    I --> J
    J -->|yes| K[per-app: name + sync + health + first resource msg]
    J -->|no| L[fallback: one or more apps unhealthy]
    K --> M[return fmt.Errorf sync failed / timed out: summary]
    L --> M
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: cmd/sikifanso/middleware_test.go
Line: 63-74

Comment:
**Missing test: message-less resource skip**

Seven tests and not a single one exercises the actual branching your comment brags about. What exactly are you testing if you skip the interesting path?

The guard on `middleware.go` line 199 — `res.Health != "" && res.Health != "Healthy" && res.Message != ""` — skips degraded resources with an empty `Message` and continues to the next one. The inline comment at line 197 explicitly calls this out (`// First unhealthy resource with a non-empty message`), yet no test case puts a message-less degraded resource first to verify the loop actually advances. Add a case:

```go
{
    name: "skips message-less resource, uses first with message",
    results: []grpcsync.Result{
        {
            App: "langfuse", SyncStatus: "Synced", Health: "Degraded",
            Resources: []grpcclient.ResourceStatus{
                {Kind: "Deployment", Name: "web",    Health: "Degraded", Message: ""},
                {Kind: "Deployment", Name: "worker", Health: "Degraded", Message: "OOMKilled"},
            },
        },
    },
    want: "langfuse (sync=Synced health=Degraded) [Deployment/worker: OOMKilled]",
},
```

A comment and no test for the exact behavior the comment describes is just a lie waiting to rot.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: correct misleading comment on unhea..."](https://github.com/sikifanso/sikifanso/commit/639b562ca439029fcb00da80ccaa9fc135b37ffa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27406770)</sub>

<!-- /greptile_comment -->