### PR TITLE
fix: eliminate spinner data race and show multi-app progress

### DIFF
--- a/cmd/sikifanso/middleware.go
+++ b/cmd/sikifanso/middleware.go
@@ -232,6 +232,8 @@ func (p *progressTracker) Update(app, status, detail string) {
 	}
 
 	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	p.status[app] = line
 
 	var sb strings.Builder
@@ -245,12 +247,9 @@ func (p *progressTracker) Update(app, status, detail string) {
 	}
 	suffix := " " + sb.String()
 	if suffix == p.lastSuffix {
-		p.mu.Unlock()
 		return
 	}
 	p.lastSuffix = suffix
-	p.mu.Unlock()
-
 	p.spinner.Lock()
 	p.spinner.Suffix = suffix
 	p.spinner.Unlock()

--- a/cmd/sikifanso/middleware.go
+++ b/cmd/sikifanso/middleware.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -103,6 +104,7 @@ func syncAfterMutation(ctx context.Context, cmd *cli.Command, sess *session.Sess
 
 	// 3. Build request with spinner for progress feedback.
 	s := spinner.New(spinner.CharSets[11], 120*time.Millisecond, spinner.WithWriter(os.Stderr))
+	progress := newProgressTracker(s, opts.Apps)
 
 	orch := grpcsync.NewOrchestrator(grpcClient, zapLogger)
 	req := grpcsync.Request{
@@ -114,13 +116,7 @@ func syncAfterMutation(ctx context.Context, cmd *cli.Command, sess *session.Sess
 		ReconcileFn: func(ctx context.Context) error {
 			return reconciler.Trigger(ctx, opts.AppSetName)
 		},
-		OnProgress: func(app, status, detail string) {
-			suffix := fmt.Sprintf(" %s  %s", app, status)
-			if detail != "" {
-				suffix += "  " + detail
-			}
-			s.Suffix = suffix
-		},
+		OnProgress: progress.Update,
 	}
 
 	// 4. No-wait mode.
@@ -207,6 +203,57 @@ func summarizeUnhealthy(results []grpcsync.Result) string {
 		return "one or more apps unhealthy"
 	}
 	return strings.Join(parts, "; ")
+}
+
+// progressTracker aggregates per-app status into a single spinner suffix so
+// that all apps remain visible during concurrent sync (without this, only the
+// last-writing goroutine's status would show).
+type progressTracker struct {
+	mu         sync.Mutex
+	spinner    *spinner.Spinner
+	apps       []string
+	status     map[string]string
+	lastSuffix string
+}
+
+func newProgressTracker(s *spinner.Spinner, apps []string) *progressTracker {
+	return &progressTracker{
+		spinner: s,
+		apps:    apps,
+		status:  make(map[string]string, len(apps)),
+	}
+}
+
+// Update records the latest status for an app and re-renders the combined suffix.
+func (p *progressTracker) Update(app, status, detail string) {
+	line := fmt.Sprintf("%s %s", app, status)
+	if detail != "" {
+		line += "  " + detail
+	}
+
+	p.mu.Lock()
+	p.status[app] = line
+
+	var sb strings.Builder
+	for _, name := range p.apps {
+		if s, ok := p.status[name]; ok {
+			if sb.Len() > 0 {
+				sb.WriteString("  │  ")
+			}
+			sb.WriteString(s)
+		}
+	}
+	suffix := " " + sb.String()
+	if suffix == p.lastSuffix {
+		p.mu.Unlock()
+		return
+	}
+	p.lastSuffix = suffix
+	p.mu.Unlock()
+
+	p.spinner.Lock()
+	p.spinner.Suffix = suffix
+	p.spinner.Unlock()
 }
 
 // buildAppTiers returns a map of app name → tier for tier-aware sequencing.

--- a/cmd/sikifanso/middleware_test.go
+++ b/cmd/sikifanso/middleware_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -91,6 +92,7 @@ func TestSummarizeUnhealthy(t *testing.T) {
 }
 
 func TestProgressTracker_SingleApp(t *testing.T) {
+	t.Parallel()
 	s := spinner.New(spinner.CharSets[11], 120*time.Millisecond, spinner.WithWriter(os.Stderr))
 	pt := newProgressTracker(s, []string{"langfuse"})
 
@@ -107,6 +109,7 @@ func TestProgressTracker_SingleApp(t *testing.T) {
 }
 
 func TestProgressTracker_MultiApp_PreservesOrder(t *testing.T) {
+	t.Parallel()
 	s := spinner.New(spinner.CharSets[11], 120*time.Millisecond, spinner.WithWriter(os.Stderr))
 	apps := []string{"valkey", "langfuse", "presidio"}
 	pt := newProgressTracker(s, apps)
@@ -127,33 +130,38 @@ func TestProgressTracker_MultiApp_PreservesOrder(t *testing.T) {
 }
 
 func TestProgressTracker_ConcurrentUpdates(t *testing.T) {
-	// This test is meaningful with -race; it verifies no data race on concurrent Update calls.
+	t.Parallel()
 	s := spinner.New(spinner.CharSets[11], 120*time.Millisecond, spinner.WithWriter(os.Stderr))
 	s.Start()
 	defer s.Stop()
 
 	apps := []string{"a", "b", "c", "d", "e"}
 	pt := newProgressTracker(s, apps)
+	const iterations = 50
 
 	var wg sync.WaitGroup
 	for _, app := range apps {
 		wg.Add(1)
 		go func(name string) {
 			defer wg.Done()
-			for i := 0; i < 50; i++ {
-				pt.Update(name, "Progressing", "wave")
+			for i := 0; i < iterations; i++ {
+				pt.Update(name, "Progressing", fmt.Sprintf("wave-%d", i))
 			}
 		}(app)
 	}
 	wg.Wait()
 
-	// After all goroutines finish, suffix must contain all five apps.
+	// After all goroutines finish, the suffix must reflect the final iteration
+	// for every app. Using iteration-specific strings ensures a stale suffix
+	// from an earlier iteration would be caught.
 	s.Lock()
 	got := s.Suffix
 	s.Unlock()
+	lastDetail := fmt.Sprintf("wave-%d", iterations-1)
 	for _, app := range apps {
-		if !strings.Contains(got, app) {
-			t.Errorf("suffix %q missing app %q", got, app)
+		want := fmt.Sprintf("%s Progressing  %s", app, lastDetail)
+		if !strings.Contains(got, want) {
+			t.Errorf("suffix missing final state for app %q\n  got:  %q\n  want fragment: %q", app, got, want)
 		}
 	}
 }

--- a/cmd/sikifanso/middleware_test.go
+++ b/cmd/sikifanso/middleware_test.go
@@ -1,7 +1,13 @@
 package main
 
 import (
+	"os"
+	"strings"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/briandowns/spinner"
 
 	"github.com/alicanalbayrak/sikifanso/internal/argocd/grpcclient"
 	"github.com/alicanalbayrak/sikifanso/internal/argocd/grpcsync"
@@ -81,5 +87,73 @@ func TestSummarizeUnhealthy(t *testing.T) {
 				t.Errorf("summarizeUnhealthy() =\n  %q\nwant:\n  %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestProgressTracker_SingleApp(t *testing.T) {
+	s := spinner.New(spinner.CharSets[11], 120*time.Millisecond, spinner.WithWriter(os.Stderr))
+	pt := newProgressTracker(s, []string{"langfuse"})
+
+	pt.Update("langfuse", "Synced/Healthy", "")
+
+	s.Lock()
+	got := s.Suffix
+	s.Unlock()
+
+	want := " langfuse Synced/Healthy"
+	if got != want {
+		t.Errorf("suffix = %q, want %q", got, want)
+	}
+}
+
+func TestProgressTracker_MultiApp_PreservesOrder(t *testing.T) {
+	s := spinner.New(spinner.CharSets[11], 120*time.Millisecond, spinner.WithWriter(os.Stderr))
+	apps := []string{"valkey", "langfuse", "presidio"}
+	pt := newProgressTracker(s, apps)
+
+	// Update in reverse order — suffix should still match the original app order.
+	pt.Update("presidio", "Synced/Healthy", "")
+	pt.Update("valkey", "OutOfSync/Progressing", "syncing")
+	pt.Update("langfuse", "Synced/Degraded", "CrashLoopBackOff")
+
+	s.Lock()
+	got := s.Suffix
+	s.Unlock()
+
+	want := " valkey OutOfSync/Progressing  syncing  │  langfuse Synced/Degraded  CrashLoopBackOff  │  presidio Synced/Healthy"
+	if got != want {
+		t.Errorf("suffix =\n  %q\nwant:\n  %q", got, want)
+	}
+}
+
+func TestProgressTracker_ConcurrentUpdates(t *testing.T) {
+	// This test is meaningful with -race; it verifies no data race on concurrent Update calls.
+	s := spinner.New(spinner.CharSets[11], 120*time.Millisecond, spinner.WithWriter(os.Stderr))
+	s.Start()
+	defer s.Stop()
+
+	apps := []string{"a", "b", "c", "d", "e"}
+	pt := newProgressTracker(s, apps)
+
+	var wg sync.WaitGroup
+	for _, app := range apps {
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
+			for i := 0; i < 50; i++ {
+				pt.Update(name, "Progressing", "wave")
+			}
+		}(app)
+	}
+	wg.Wait()
+
+	// After all goroutines finish, suffix must contain all five apps.
+	s.Lock()
+	got := s.Suffix
+	s.Unlock()
+	for _, app := range apps {
+		if !strings.Contains(got, app) {
+			t.Errorf("suffix %q missing app %q", got, app)
+		}
 	}
 }

--- a/docs/superpowers/reports/2026-04-04-argocd-deployment-progress.md
+++ b/docs/superpowers/reports/2026-04-04-argocd-deployment-progress.md
@@ -22,9 +22,9 @@
 | P10 | Medium | pollOnce fallback gives single stale snapshot | **Done** | `fc64572` — pollUntilTerminal loop; `1417023`, `4fd8bf1` — review fixes |
 | P11 | Medium | waitForAppear always waits >=5s (no initial check) | Open | |
 | P12 | Medium | SyncApplication called without operation-state guard | Open | |
-| P13 | Medium | Error messages discard all context | Open | |
+| P13 | Medium | Error messages discard all context | **Done** | PR #16 — summarizeUnhealthy with per-app diagnostics |
 | P14 | Medium | Default branch conflates Progressing and Unknown | Open | |
-| P15 | Medium | Spinner suffix data race under concurrent watches | Open | |
+| P15 | Medium | Spinner suffix data race under concurrent watches | **Done** | progressTracker with mutex + spinner Lock/Unlock |
 | P16 | Medium | ReconcileFn error swallowed, causes full-timeout block | Open | |
 | P17 | Medium | Root ApplicationSets start concurrently — resource contention | **Done** | PR #15 — phased bootstrap: infra AppSet → health gate → workload AppSets |
 | P18 | Medium | ResourceTree misses sync error messages | Open | |
@@ -54,8 +54,8 @@
 | T10 | Medium | Tier-aware watchApps goroutine sequencing | **Done** | P6 — PR #13; tier-aware sequencing + reverse order for disable |
 | T11 | Medium | ArgoCD gRPC readiness probe after install | **Done** | P4 — WaitForGRPC polls Version endpoint; installInfra extracted from Create |
 | T12 | Medium | Startup ApplicationSet sequencing in cluster create | **Done** | P17 — PR #15; phased bootstrap with WaitForApplicationsHealthy |
-| T13 | Medium | Actionable error messages from Result slice | Open | P13 |
-| T14 | Medium | Fix spinner data race + multi-app progress | Open | P15 |
+| T13 | Medium | Actionable error messages from Result slice | **Done** | P13 — PR #16 |
+| T14 | Medium | Fix spinner data race + multi-app progress | **Done** | P15 — progressTracker with mutex + multi-app suffix |
 | T15 | Medium | Temporal per-service resources + disable Elasticsearch | Open | P21 |
 | T16 | Medium | Reduce Prometheus PVC + add retentionSize guard | Open | P22 |
 | T17 | Medium | Separate ResourceQuota requests/limits in agent-template | Open | P23 |
@@ -64,8 +64,8 @@
 
 ## Summary
 
-- **Completed**: 15/17 tasks (T1–T12 + associated review fixes)
+- **Completed**: 14/17 tasks (T1–T14 + associated review fixes)
 - **Remaining Critical**: 0
 - **Remaining High**: 0
-- **Remaining Medium**: 6 (T12–T17)
+- **Remaining Medium**: 3 (T15–T17)
 - **Low (no task)**: 2 (P24, P25)


### PR DESCRIPTION
## Summary

- Replace the inline `OnProgress` closure in `syncAfterMutation` with a `progressTracker` type that serialises concurrent writes via `sync.Mutex` and uses the spinner's exported `Lock`/`Unlock` for safe suffix assignment
- Aggregate all app statuses into a single combined suffix (preserving original app order) so every app remains visible instead of only the last-writing goroutine's status
- Skip the spinner lock entirely when the rendered suffix hasn't changed (deduplication)

## Test plan

- [x] `go test ./cmd/sikifanso/ -race -v` — all 10 tests pass with race detector
- [x] `TestProgressTracker_SingleApp` — single app suffix rendered correctly
- [x] `TestProgressTracker_MultiApp_PreservesOrder` — updates in reverse order still display in original app order
- [x] `TestProgressTracker_ConcurrentUpdates` — 5 goroutines × 50 updates with spinner running, no race detected, all apps present in final suffix

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

**[Linus Torvalds Mode]**

Congratulations, you have graduated from "shipping a data race" to "shipping a fix for the data race," which I suppose counts as forward progress in this industry. The PR introduces a `progressTracker` struct in `cmd/sikifanso/middleware.go` that serialises concurrent `OnProgress` callbacks via `sync.Mutex`, aggregates all app statuses into a single combined spinner suffix in the original declared app order, and deduplicates identical suffix writes to avoid pointless lock churn on the spinner.

The two issues flagged in the prior review threads are now correctly addressed:
- **TOCTOU between `lastSuffix` and spinner write**: `defer p.mu.Unlock()` keeps `p.mu` held across both `p.lastSuffix = suffix` (line 252) *and* the `p.spinner.Lock()` / write / `p.spinner.Unlock()` sequence (lines 253-255), eliminating the window where a concurrent goroutine could interleave a newer write and leave the spinner pinned on a stale value permanently.
- **Concurrent test coverage gap**: `TestProgressTracker_ConcurrentUpdates` now drives iteration-specific strings (`fmt.Sprintf("wave-%d", i)`) and asserts that `wave-49` appears in the final suffix for every app after `wg.Wait()`, making it capable of detecting exactly the stale-suffix regression it was written to prevent.

No new P0 or P1 issues found. The implicit lock-ordering invariant (`p.mu` always acquired before `p.spinner.Lock()`) is consistently upheld across the single call-site in `Update`, so deadlock is not a concern.

I grudgingly acknowledge this is now mergeable — "fixed the race created while fixing the original race" is not the career highlight one might hope for, but at least the code is correct now.

<h3>Confidence Score: 5/5</h3>

**[Linus Torvalds Mode]** This PR somehow managed to fix the race it introduced in the same PR cycle, which is a low bar but one that has apparently been cleared. It is safe to merge.

Who writes a data race and then fixes it in the same PR? Anyway. The prior P1 concerns (TOCTOU on lastSuffix + spinner write, and the useless same-string concurrent test) are both resolved in the HEAD commit. defer p.mu.Unlock() ensures the mutex is held across the full spinner-write critical section with no interleaving window. The test now uses wave-N strings and correctly asserts final state. No remaining P0 or P1 findings — score is 5.

Nothing needs babysitting here, which is more than I expected from this PR. middleware.go and middleware_test.go are the only files that matter and both look correct.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/sikifanso/middleware.go | Introduces progressTracker; defer-based p.mu.Unlock() correctly closes the TOCTOU window flagged in prior review; no new issues. |
| cmd/sikifanso/middleware_test.go | ConcurrentUpdates test upgraded to iteration-specific strings and final-state assertion; correctly validates that wave-49 is present for all apps post-wg.Wait(). |
| docs/superpowers/reports/2026-04-04-argocd-deployment-progress.md | Documentation-only report; no code changes. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GA as Goroutine A
    participant GB as Goroutine B
    participant PT as progressTracker
    participant SP as spinner.Spinner

    GA->>PT: Update("app-a", "Synced", "")
    PT->>PT: p.mu.Lock() + defer Unlock
    PT->>PT: p.status["app-a"] = line
    PT->>PT: build combined suffix
    PT->>SP: Lock()
    PT->>SP: Suffix = combined
    PT->>SP: Unlock()
    Note over PT: p.mu.Unlock() (defer)

    GB->>PT: Update("app-b", "Progressing", "wave-3")
    PT->>PT: p.mu.Lock() + defer Unlock
    PT->>PT: p.status["app-b"] = line
    PT->>PT: build combined suffix
    alt suffix unchanged (dedup)
        PT-->>GB: return early
    else suffix changed
        PT->>SP: Lock()
        PT->>SP: Suffix = new combined
        PT->>SP: Unlock()
    end
    Note over PT: p.mu.Unlock() (defer)
```

<sub>Reviews (2): Last reviewed commit: ["fix: hold p.mu across spinner write to c..."](https://github.com/sikifanso/sikifanso/commit/bbbbf4dae0ec5ae84ba53971e30daf65e8722fc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27408209)</sub>

<!-- /greptile_comment -->