### PR TITLE
fix: separate agent ResourceQuota requests and limits

### DIFF
--- a/cmd/sikifanso/agent_cmd.go
+++ b/cmd/sikifanso/agent_cmd.go
@@ -30,9 +30,11 @@ func agentCreateCmd() *cli.Command {
 		Usage:     "Create an isolated agent namespace",
 		ArgsUsage: "NAME",
 		Flags: append([]cli.Flag{
-			&cli.StringFlag{Name: "cpu", Usage: "CPU quota", Value: "500m"},
-			&cli.StringFlag{Name: "memory", Usage: "Memory quota", Value: "512Mi"},
-			&cli.StringFlag{Name: "pods", Usage: "Max pods", Value: "10"},
+			&cli.StringFlag{Name: "cpu-request", Usage: "CPU request quota (guaranteed)", Value: agent.DefaultCPURequest},
+			&cli.StringFlag{Name: "cpu-limit", Usage: "CPU limit quota (burst ceiling)", Value: agent.DefaultCPULimit},
+			&cli.StringFlag{Name: "memory-request", Usage: "Memory request quota (guaranteed)", Value: agent.DefaultMemoryRequest},
+			&cli.StringFlag{Name: "memory-limit", Usage: "Memory limit quota (burst ceiling)", Value: agent.DefaultMemoryLimit},
+			&cli.StringFlag{Name: "pods", Usage: "Max pods", Value: agent.DefaultPods},
 		}, waitSyncFlags()...),
 		Action: withSession(func(ctx context.Context, cmd *cli.Command, sess *session.Session) error {
 			name := cmd.Args().First()
@@ -41,10 +43,12 @@ func agentCreateCmd() *cli.Command {
 			}
 
 			if err := agent.Create(sess.GitOpsPath, agent.CreateOpts{
-				Name:   name,
-				CPU:    cmd.String("cpu"),
-				Memory: cmd.String("memory"),
-				Pods:   cmd.String("pods"),
+				Name:          name,
+				CPURequest:    cmd.String("cpu-request"),
+				CPULimit:      cmd.String("cpu-limit"),
+				MemoryRequest: cmd.String("memory-request"),
+				MemoryLimit:   cmd.String("memory-limit"),
+				Pods:          cmd.String("pods"),
 			}); err != nil {
 				return err
 			}
@@ -84,10 +88,10 @@ func agentListCmd() *cli.Command {
 				return nil
 			}
 
-			headers := []string{"NAME", "NAMESPACE", "CPU", "MEMORY", "PODS"}
+			headers := []string{"NAME", "NAMESPACE", "CPU REQ", "CPU LIM", "MEM REQ", "MEM LIM", "PODS"}
 			rows := make([][]string, 0, len(agents))
 			for _, a := range agents {
-				rows = append(rows, []string{a.Name, a.Namespace, a.CPU, a.Memory, a.Pods})
+				rows = append(rows, []string{a.Name, a.Namespace, a.CPURequest, a.CPULimit, a.MemoryRequest, a.MemoryLimit, a.Pods})
 			}
 			printTable(os.Stderr, headers, rows)
 			return nil

--- a/docs/superpowers/reports/2026-04-04-argocd-deployment-progress.md
+++ b/docs/superpowers/reports/2026-04-04-argocd-deployment-progress.md
@@ -32,7 +32,7 @@
 | P20 | Medium | agent-full exceeds safe memory for 8-16 GiB hosts | Open | |
 | P21 | Medium | Temporal values missing per-service resources + Elasticsearch | **Done** | Per-service resources + elasticsearch.enabled: false |
 | P22 | Medium | Prometheus PVC oversized at 20 GiB | **Done** | PVC 20Gi→5Gi, retentionSize 4GB, Alertmanager 5Gi→1Gi |
-| P23 | Medium | Agent sandbox ResourceQuota forces Guaranteed QoS | Open | |
+| P23 | Medium | Agent sandbox ResourceQuota forces Guaranteed QoS | **Done** | Split cpu/memory into separate request/limit quota values |
 | P24 | Low | cnpg-operator has no resource requests/limits | Open | |
 | P25 | Low | nemo-guardrails has no LLM endpoint configured | Open | |
 
@@ -58,14 +58,14 @@
 | T14 | Medium | Fix spinner data race + multi-app progress | **Done** | P15 — progressTracker with mutex + multi-app suffix |
 | T15 | Medium | Temporal per-service resources + disable Elasticsearch | **Done** | P21 — per-service resource blocks + elasticsearch.enabled: false |
 | T16 | Medium | Reduce Prometheus PVC + add retentionSize guard | **Done** | P22 — PVC 20Gi→5Gi + retentionSize 4GB + Alertmanager 5Gi→1Gi |
-| T17 | Medium | Separate ResourceQuota requests/limits in agent-template | Open | P23 |
+| T17 | Medium | Separate ResourceQuota requests/limits in agent-template | **Done** | P23 — separate cpuRequest/cpuLimit/memoryRequest/memoryLimit; defaults allow Burstable QoS |
 
 ---
 
 ## Summary
 
-- **Completed**: 16/17 tasks (T1–T16 + associated review fixes)
+- **Completed**: 17/17 tasks (T1–T17 + associated review fixes)
 - **Remaining Critical**: 0
 - **Remaining High**: 0
-- **Remaining Medium**: 1 (T17)
+- **Remaining Medium**: 0
 - **Low (no task)**: 2 (P24, P25)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -18,6 +18,12 @@ const (
 	DefaultChartRepoURL = "https://sikifanso.github.io/sikifanso-agent-template"
 	// DefaultChartVersion is the default chart version to deploy.
 	DefaultChartVersion = "0.1.0"
+
+	DefaultCPURequest    = "250m"
+	DefaultCPULimit      = "1000m"
+	DefaultMemoryRequest = "256Mi"
+	DefaultMemoryLimit   = "1Gi"
+	DefaultPods          = "10"
 )
 
 // entry is the YAML structure written to agents/<name>.yaml.
@@ -35,29 +41,35 @@ type values struct {
 }
 
 type agentValues struct {
-	Name   string `json:"name"`
-	CPU    string `json:"cpu"`
-	Memory string `json:"memory"`
-	Pods   string `json:"pods"`
+	Name          string `json:"name"`
+	CPURequest    string `json:"cpuRequest"`
+	CPULimit      string `json:"cpuLimit"`
+	MemoryRequest string `json:"memoryRequest"`
+	MemoryLimit   string `json:"memoryLimit"`
+	Pods          string `json:"pods"`
 }
 
 // CreateOpts configures agent creation.
 type CreateOpts struct {
-	Name         string
-	CPU          string
-	Memory       string
-	Pods         string
-	ChartRepoURL string
-	ChartVersion string
+	Name          string
+	CPURequest    string
+	CPULimit      string
+	MemoryRequest string
+	MemoryLimit   string
+	Pods          string
+	ChartRepoURL  string
+	ChartVersion  string
 }
 
 // Info holds agent metadata for display.
 type Info struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
-	CPU       string `json:"cpu"`
-	Memory    string `json:"memory"`
-	Pods      string `json:"pods"`
+	Name          string `json:"name"`
+	Namespace     string `json:"namespace"`
+	CPURequest    string `json:"cpuRequest"`
+	CPULimit      string `json:"cpuLimit"`
+	MemoryRequest string `json:"memoryRequest"`
+	MemoryLimit   string `json:"memoryLimit"`
+	Pods          string `json:"pods"`
 }
 
 var validName = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
@@ -90,17 +102,25 @@ func Create(gitOpsPath string, opts CreateOpts) error {
 	if chartVersion == "" {
 		chartVersion = DefaultChartVersion
 	}
-	cpu := opts.CPU
-	if cpu == "" {
-		cpu = "500m"
+	cpuReq := opts.CPURequest
+	if cpuReq == "" {
+		cpuReq = DefaultCPURequest
 	}
-	mem := opts.Memory
-	if mem == "" {
-		mem = "512Mi"
+	cpuLim := opts.CPULimit
+	if cpuLim == "" {
+		cpuLim = DefaultCPULimit
+	}
+	memReq := opts.MemoryRequest
+	if memReq == "" {
+		memReq = DefaultMemoryRequest
+	}
+	memLim := opts.MemoryLimit
+	if memLim == "" {
+		memLim = DefaultMemoryLimit
 	}
 	pods := opts.Pods
 	if pods == "" {
-		pods = "10"
+		pods = DefaultPods
 	}
 
 	e := entry{
@@ -113,10 +133,12 @@ func Create(gitOpsPath string, opts CreateOpts) error {
 
 	v := values{
 		Agent: agentValues{
-			Name:   opts.Name,
-			CPU:    cpu,
-			Memory: mem,
-			Pods:   pods,
+			Name:          opts.Name,
+			CPURequest:    cpuReq,
+			CPULimit:      cpuLim,
+			MemoryRequest: memReq,
+			MemoryLimit:   memLim,
+			Pods:          pods,
 		},
 	}
 
@@ -139,6 +161,23 @@ func Create(gitOpsPath string, opts CreateOpts) error {
 	}
 
 	return gitops.Commit(gitOpsPath, fmt.Sprintf("agent: create %s", opts.Name), entryPath, valuesPath)
+}
+
+// populateQuota reads an agent values file and fills quota fields on info.
+func populateQuota(info *Info, valuesFile string) {
+	vData, err := os.ReadFile(valuesFile)
+	if err != nil {
+		return
+	}
+	var v values
+	if err := yaml.Unmarshal(vData, &v); err != nil {
+		return
+	}
+	info.CPURequest = v.Agent.CPURequest
+	info.CPULimit = v.Agent.CPULimit
+	info.MemoryRequest = v.Agent.MemoryRequest
+	info.MemoryLimit = v.Agent.MemoryLimit
+	info.Pods = v.Agent.Pods
 }
 
 // List reads all agent entries from the agents directory.
@@ -168,20 +207,12 @@ func List(gitOpsPath string) ([]Info, error) {
 			return nil, fmt.Errorf("parsing agent file %s: %w", e.Name(), err)
 		}
 
-		// Read values for quota info.
 		info := Info{
 			Name:      ent.Name,
 			Namespace: ent.Namespace,
 		}
 		valuesFile := filepath.Join(dir, "values", ent.Name+".yaml")
-		if vData, err := os.ReadFile(valuesFile); err == nil {
-			var v values
-			if err := yaml.Unmarshal(vData, &v); err == nil {
-				info.CPU = v.Agent.CPU
-				info.Memory = v.Agent.Memory
-				info.Pods = v.Agent.Pods
-			}
-		}
+		populateQuota(&info, valuesFile)
 
 		agents = append(agents, info)
 	}
@@ -221,14 +252,7 @@ func Find(gitOpsPath, name string) (*Info, error) {
 
 	info := &Info{Name: ent.Name, Namespace: ent.Namespace}
 	valuesFile := filepath.Join(AgentsDir(gitOpsPath), "values", name+".yaml")
-	if vData, err := os.ReadFile(valuesFile); err == nil {
-		var v values
-		if err := yaml.Unmarshal(vData, &v); err == nil {
-			info.CPU = v.Agent.CPU
-			info.Memory = v.Agent.Memory
-			info.Pods = v.Agent.Pods
-		}
-	}
+	populateQuota(info, valuesFile)
 	return info, nil
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -75,6 +75,16 @@ type Info struct {
 
 var validName = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 
+func validateName(name string) error {
+	if name == "" {
+		return fmt.Errorf("agent name is required")
+	}
+	if !validName.MatchString(name) {
+		return fmt.Errorf("invalid agent name %q: must match [a-z0-9][a-z0-9-]*", name)
+	}
+	return nil
+}
+
 // checkPair validates that a resource request does not exceed its limit.
 func checkPair(req, lim, label string) error {
 	r, err := resource.ParseQuantity(req)
@@ -106,11 +116,8 @@ func AgentsDir(gitOpsPath string) string {
 
 // Create writes agent entry and values files, then commits to the gitops repo.
 func Create(gitOpsPath string, opts CreateOpts) error {
-	if opts.Name == "" {
-		return fmt.Errorf("agent name is required")
-	}
-	if !validName.MatchString(opts.Name) {
-		return fmt.Errorf("invalid agent name %q: must match [a-z0-9][a-z0-9-]*", opts.Name)
+	if err := validateName(opts.Name); err != nil {
+		return err
 	}
 
 	entryPath := filepath.Join("agents", opts.Name+".yaml")
@@ -254,6 +261,9 @@ func List(gitOpsPath string) ([]Info, error) {
 
 // Find returns the agent with the given name or an error.
 func Find(gitOpsPath, name string) (*Info, error) {
+	if err := validateName(name); err != nil {
+		return nil, err
+	}
 	entryFile := filepath.Join(AgentsDir(gitOpsPath), name+".yaml")
 	data, err := os.ReadFile(entryFile)
 	if err != nil {
@@ -287,6 +297,9 @@ func Find(gitOpsPath, name string) (*Info, error) {
 
 // Delete removes agent entry and values files, then commits.
 func Delete(gitOpsPath, name string) error {
+	if err := validateName(name); err != nil {
+		return err
+	}
 	entryPath := filepath.Join("agents", name+".yaml")
 	absEntry := filepath.Join(gitOpsPath, entryPath)
 	if _, err := os.Stat(absEntry); os.IsNotExist(err) {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/alicanalbayrak/sikifanso/internal/gitops"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/yaml"
 )
 
@@ -74,6 +75,33 @@ type Info struct {
 
 var validName = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 
+// validateQuotas checks that resource requests do not exceed limits.
+func validateQuotas(cpuReq, cpuLim, memReq, memLim string) error {
+	cr, err := resource.ParseQuantity(cpuReq)
+	if err != nil {
+		return fmt.Errorf("invalid cpuRequest %q: %w", cpuReq, err)
+	}
+	cl, err := resource.ParseQuantity(cpuLim)
+	if err != nil {
+		return fmt.Errorf("invalid cpuLimit %q: %w", cpuLim, err)
+	}
+	if cr.Cmp(cl) > 0 {
+		return fmt.Errorf("cpuRequest (%s) exceeds cpuLimit (%s)", cpuReq, cpuLim)
+	}
+	mr, err := resource.ParseQuantity(memReq)
+	if err != nil {
+		return fmt.Errorf("invalid memoryRequest %q: %w", memReq, err)
+	}
+	ml, err := resource.ParseQuantity(memLim)
+	if err != nil {
+		return fmt.Errorf("invalid memoryLimit %q: %w", memLim, err)
+	}
+	if mr.Cmp(ml) > 0 {
+		return fmt.Errorf("memoryRequest (%s) exceeds memoryLimit (%s)", memReq, memLim)
+	}
+	return nil
+}
+
 // AgentsDir returns the path to the agents directory within gitOpsPath.
 func AgentsDir(gitOpsPath string) string {
 	return filepath.Join(gitOpsPath, "agents")
@@ -121,6 +149,10 @@ func Create(gitOpsPath string, opts CreateOpts) error {
 	pods := opts.Pods
 	if pods == "" {
 		pods = DefaultPods
+	}
+
+	if err := validateQuotas(cpuReq, cpuLim, memReq, memLim); err != nil {
+		return err
 	}
 
 	e := entry{

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -75,31 +75,28 @@ type Info struct {
 
 var validName = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 
-// validateQuotas checks that resource requests do not exceed limits.
-func validateQuotas(cpuReq, cpuLim, memReq, memLim string) error {
-	cr, err := resource.ParseQuantity(cpuReq)
+// checkPair validates that a resource request does not exceed its limit.
+func checkPair(req, lim, label string) error {
+	r, err := resource.ParseQuantity(req)
 	if err != nil {
-		return fmt.Errorf("invalid cpuRequest %q: %w", cpuReq, err)
+		return fmt.Errorf("invalid %sRequest %q: %w", label, req, err)
 	}
-	cl, err := resource.ParseQuantity(cpuLim)
+	l, err := resource.ParseQuantity(lim)
 	if err != nil {
-		return fmt.Errorf("invalid cpuLimit %q: %w", cpuLim, err)
+		return fmt.Errorf("invalid %sLimit %q: %w", label, lim, err)
 	}
-	if cr.Cmp(cl) > 0 {
-		return fmt.Errorf("cpuRequest (%s) exceeds cpuLimit (%s)", cpuReq, cpuLim)
-	}
-	mr, err := resource.ParseQuantity(memReq)
-	if err != nil {
-		return fmt.Errorf("invalid memoryRequest %q: %w", memReq, err)
-	}
-	ml, err := resource.ParseQuantity(memLim)
-	if err != nil {
-		return fmt.Errorf("invalid memoryLimit %q: %w", memLim, err)
-	}
-	if mr.Cmp(ml) > 0 {
-		return fmt.Errorf("memoryRequest (%s) exceeds memoryLimit (%s)", memReq, memLim)
+	if r.Cmp(l) > 0 {
+		return fmt.Errorf("%sRequest (%s) exceeds %sLimit (%s)", label, req, label, lim)
 	}
 	return nil
+}
+
+// validateQuotas checks that resource requests do not exceed limits.
+func validateQuotas(cpuReq, cpuLim, memReq, memLim string) error {
+	if err := checkPair(cpuReq, cpuLim, "cpu"); err != nil {
+		return err
+	}
+	return checkPair(memReq, memLim, "memory")
 }
 
 // AgentsDir returns the path to the agents directory within gitOpsPath.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -20,11 +20,16 @@ const (
 	// DefaultChartVersion is the default chart version to deploy.
 	DefaultChartVersion = "0.1.0"
 
-	DefaultCPURequest    = "250m"
-	DefaultCPULimit      = "1000m"
+	// DefaultCPURequest is the default CPU request quota for an agent namespace.
+	DefaultCPURequest = "250m"
+	// DefaultCPULimit is the default CPU limit quota for an agent namespace.
+	DefaultCPULimit = "1000m"
+	// DefaultMemoryRequest is the default memory request quota for an agent namespace.
 	DefaultMemoryRequest = "256Mi"
-	DefaultMemoryLimit   = "1Gi"
-	DefaultPods          = "10"
+	// DefaultMemoryLimit is the default memory limit quota for an agent namespace.
+	DefaultMemoryLimit = "1Gi"
+	// DefaultPods is the default maximum pod count for an agent namespace.
+	DefaultPods = "10"
 )
 
 // entry is the YAML structure written to agents/<name>.yaml.
@@ -203,10 +208,12 @@ func Create(gitOpsPath string, opts CreateOpts) error {
 func populateQuota(info *Info, valuesFile string) {
 	vData, err := os.ReadFile(valuesFile)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to read agent values file %s: %v\n", valuesFile, err)
 		return
 	}
 	var v values
 	if err := yaml.Unmarshal(vData, &v); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to parse agent values file %s: %v\n", valuesFile, err)
 		return
 	}
 	info.CPURequest = v.Agent.CPURequest

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -106,6 +106,35 @@ func TestCreate_DuplicateReturnsError(t *testing.T) {
 	}
 }
 
+func TestCreate_RequestExceedsLimitReturnsError(t *testing.T) {
+	t.Parallel()
+	dir := setupGitOps(t)
+
+	// CPU request > limit
+	err := Create(dir, CreateOpts{Name: "bad-cpu", CPURequest: "2000m", CPULimit: "500m"})
+	if err == nil {
+		t.Fatal("expected error when cpuRequest > cpuLimit")
+	}
+	if !contains(err.Error(), "cpuRequest") || !contains(err.Error(), "exceeds") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+
+	// Memory request > limit
+	err = Create(dir, CreateOpts{Name: "bad-mem", MemoryRequest: "2Gi", MemoryLimit: "512Mi"})
+	if err == nil {
+		t.Fatal("expected error when memoryRequest > memoryLimit")
+	}
+	if !contains(err.Error(), "memoryRequest") || !contains(err.Error(), "exceeds") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+
+	// Invalid quantity format
+	err = Create(dir, CreateOpts{Name: "bad-fmt", CPURequest: "notaunit"})
+	if err == nil {
+		t.Fatal("expected error for invalid quantity")
+	}
+}
+
 func TestCreate_InvalidNameReturnsError(t *testing.T) {
 	t.Parallel()
 	dir := setupGitOps(t)

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -128,6 +128,12 @@ func TestCreate_RequestExceedsLimitReturnsError(t *testing.T) {
 		t.Errorf("unexpected error message: %v", err)
 	}
 
+	// Request == limit is valid (Guaranteed QoS)
+	err = Create(dir, CreateOpts{Name: "equal-rl", CPURequest: "500m", CPULimit: "500m", MemoryRequest: "1Gi", MemoryLimit: "1Gi"})
+	if err != nil {
+		t.Fatalf("request == limit should be valid: %v", err)
+	}
+
 	// Invalid quantity format
 	err = Create(dir, CreateOpts{Name: "bad-fmt", CPURequest: "notaunit"})
 	if err == nil {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -201,8 +201,20 @@ func TestFind_Existing(t *testing.T) {
 	if info.Name != "found-me" {
 		t.Errorf("Name = %q, want found-me", info.Name)
 	}
+	if info.CPURequest != DefaultCPURequest {
+		t.Errorf("CPURequest = %q, want %s", info.CPURequest, DefaultCPURequest)
+	}
 	if info.CPULimit != "2000m" {
 		t.Errorf("CPULimit = %q, want 2000m", info.CPULimit)
+	}
+	if info.MemoryRequest != DefaultMemoryRequest {
+		t.Errorf("MemoryRequest = %q, want %s", info.MemoryRequest, DefaultMemoryRequest)
+	}
+	if info.MemoryLimit != DefaultMemoryLimit {
+		t.Errorf("MemoryLimit = %q, want %s", info.MemoryLimit, DefaultMemoryLimit)
+	}
+	if info.Pods != DefaultPods {
+		t.Errorf("Pods = %q, want %s", info.Pods, DefaultPods)
 	}
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -12,10 +12,12 @@ func TestCreate_WritesEntryAndValues(t *testing.T) {
 	dir := setupGitOps(t)
 
 	err := Create(dir, CreateOpts{
-		Name:   "my-agent",
-		CPU:    "250m",
-		Memory: "256Mi",
-		Pods:   "5",
+		Name:          "my-agent",
+		CPURequest:    "125m",
+		CPULimit:      "500m",
+		MemoryRequest: "128Mi",
+		MemoryLimit:   "512Mi",
+		Pods:          "5",
 	})
 	if err != nil {
 		t.Fatalf("Create error: %v", err)
@@ -38,18 +40,24 @@ func TestCreate_WritesEntryAndValues(t *testing.T) {
 		t.Error("entry missing chart")
 	}
 
-	// Values file exists.
+	// Values file exists with separate request/limit fields.
 	valuesFile := filepath.Join(dir, "agents", "values", "my-agent.yaml")
 	vData, err := os.ReadFile(valuesFile)
 	if err != nil {
 		t.Fatalf("values file not found: %v", err)
 	}
 	vContent := string(vData)
-	if !contains(vContent, "cpu: 250m") {
-		t.Error("values missing cpu")
+	if !contains(vContent, "cpuRequest: 125m") {
+		t.Error("values missing cpuRequest")
 	}
-	if !contains(vContent, "memory: 256Mi") {
-		t.Error("values missing memory")
+	if !contains(vContent, "cpuLimit: 500m") {
+		t.Error("values missing cpuLimit")
+	}
+	if !contains(vContent, "memoryRequest: 128Mi") {
+		t.Error("values missing memoryRequest")
+	}
+	if !contains(vContent, "memoryLimit: 512Mi") {
+		t.Error("values missing memoryLimit")
 	}
 }
 
@@ -68,11 +76,17 @@ func TestCreate_DefaultValues(t *testing.T) {
 		t.Fatalf("values file not found: %v", err)
 	}
 	content := string(data)
-	if !contains(content, "cpu: 500m") {
-		t.Error("expected default cpu 500m")
+	if !contains(content, "cpuRequest: 250m") {
+		t.Error("expected default cpuRequest 250m")
 	}
-	if !contains(content, "memory: 512Mi") {
-		t.Error("expected default memory 512Mi")
+	if !contains(content, "cpuLimit: 1000m") {
+		t.Error("expected default cpuLimit 1000m")
+	}
+	if !contains(content, "memoryRequest: 256Mi") {
+		t.Error("expected default memoryRequest 256Mi")
+	}
+	if !contains(content, "memoryLimit: 1Gi") {
+		t.Error("expected default memoryLimit 1Gi")
 	}
 	if !contains(content, "pods: \"10\"") {
 		t.Error("expected default pods 10")
@@ -141,7 +155,7 @@ func TestList_EmptyDir(t *testing.T) {
 func TestFind_Existing(t *testing.T) {
 	t.Parallel()
 	dir := setupGitOps(t)
-	if err := Create(dir, CreateOpts{Name: "found-me", CPU: "1000m"}); err != nil {
+	if err := Create(dir, CreateOpts{Name: "found-me", CPULimit: "2000m"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -152,8 +166,8 @@ func TestFind_Existing(t *testing.T) {
 	if info.Name != "found-me" {
 		t.Errorf("Name = %q, want found-me", info.Name)
 	}
-	if info.CPU != "1000m" {
-		t.Errorf("CPU = %q, want 1000m", info.CPU)
+	if info.CPULimit != "2000m" {
+		t.Errorf("CPULimit = %q, want 2000m", info.CPULimit)
 	}
 }
 

--- a/internal/mcp/agent.go
+++ b/internal/mcp/agent.go
@@ -19,11 +19,13 @@ type agentInfoInput struct {
 }
 
 type agentCreateInput struct {
-	Cluster string `json:"cluster" jsonschema:"Name of the cluster"`
-	Name    string `json:"name" jsonschema:"Name for the new agent"`
-	CPU     string `json:"cpu,omitempty" jsonschema:"CPU quota, e.g. 500m"`
-	Memory  string `json:"memory,omitempty" jsonschema:"Memory quota, e.g. 512Mi"`
-	Pods    string `json:"pods,omitempty" jsonschema:"Max pods, e.g. 10"`
+	Cluster       string `json:"cluster" jsonschema:"Name of the cluster"`
+	Name          string `json:"name" jsonschema:"Name for the new agent"`
+	CPURequest    string `json:"cpuRequest,omitempty" jsonschema:"CPU request quota (guaranteed), e.g. 250m"`
+	CPULimit      string `json:"cpuLimit,omitempty" jsonschema:"CPU limit quota (burst ceiling), e.g. 1000m"`
+	MemoryRequest string `json:"memoryRequest,omitempty" jsonschema:"Memory request quota (guaranteed), e.g. 256Mi"`
+	MemoryLimit   string `json:"memoryLimit,omitempty" jsonschema:"Memory limit quota (burst ceiling), e.g. 1Gi"`
+	Pods          string `json:"pods,omitempty" jsonschema:"Max pods, e.g. 10"`
 }
 
 type agentDeleteInput struct {
@@ -50,8 +52,8 @@ func registerAgentTools(s *mcp.Server, deps *Deps) {
 		var sb strings.Builder
 		sb.WriteString("Agents:\n")
 		for _, a := range agents {
-			fmt.Fprintf(&sb, "  - %s (namespace: %s, cpu: %s, memory: %s, pods: %s)\n",
-				a.Name, a.Namespace, a.CPU, a.Memory, a.Pods)
+			fmt.Fprintf(&sb, "  - %s (namespace: %s, cpu: %s/%s, memory: %s/%s, pods: %s)\n",
+				a.Name, a.Namespace, a.CPURequest, a.CPULimit, a.MemoryRequest, a.MemoryLimit, a.Pods)
 		}
 		return textResult(sb.String())
 	})
@@ -71,8 +73,8 @@ func registerAgentTools(s *mcp.Server, deps *Deps) {
 		var sb strings.Builder
 		fmt.Fprintf(&sb, "Agent: %s\n", info.Name)
 		fmt.Fprintf(&sb, "Namespace: %s\n", info.Namespace)
-		fmt.Fprintf(&sb, "CPU Quota: %s\n", info.CPU)
-		fmt.Fprintf(&sb, "Memory Quota: %s\n", info.Memory)
+		fmt.Fprintf(&sb, "CPU: %s request / %s limit\n", info.CPURequest, info.CPULimit)
+		fmt.Fprintf(&sb, "Memory: %s request / %s limit\n", info.MemoryRequest, info.MemoryLimit)
 		fmt.Fprintf(&sb, "Max Pods: %s\n", info.Pods)
 		return textResult(sb.String())
 	})
@@ -87,10 +89,12 @@ func registerAgentTools(s *mcp.Server, deps *Deps) {
 		}
 
 		opts := agent.CreateOpts{
-			Name:   input.Name,
-			CPU:    input.CPU,
-			Memory: input.Memory,
-			Pods:   input.Pods,
+			Name:          input.Name,
+			CPURequest:    input.CPURequest,
+			CPULimit:      input.CPULimit,
+			MemoryRequest: input.MemoryRequest,
+			MemoryLimit:   input.MemoryLimit,
+			Pods:          input.Pods,
 		}
 		if err := agent.Create(sess.GitOpsPath, opts); err != nil {
 			return errResult(err)


### PR DESCRIPTION
## Summary
- Split `--cpu`/`--memory` CLI flags into `--cpu-request`/`--cpu-limit` and `--memory-request`/`--memory-limit`
- Export default constants from `agent` package to avoid magic string duplication
- Extract `populateQuota` helper to deduplicate values-to-Info mapping in List/Find
- Update MCP `agent_create`/`agent_info`/`agent_list` tools for new fields
- Mark T17/P23 done in progress tracker (17/17 tasks complete)

## Context
Companion to sikifanso/sikifanso-agent-template#1. Updates the CLI and MCP server to match the new agent-template chart values that split ResourceQuota into separate request/limit fields.

## Test plan
- [x] `go test ./... -race` — all packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [ ] `sikifanso agent create test-agent` produces correct values YAML

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

**[Linus Torvalds Mode]**

Congratulations — someone finally admitted that cramming requests AND limits into a single `--cpu` flag was an embarrassing oversight, and actually fixed it instead of leaving it as "technical debt" forever. This PR competently splits the `--cpu`/`--memory` CLI flags into `--cpu-request`/`--cpu-limit`/`--memory-request`/`--memory-limit`, exports five `Default*` constants from the `agent` package to kill magic-string duplication across callers, extracts a `populateQuota` helper to DRY out the values-file parse/assign logic that was copy-pasted between `List` and `Find`, and updates the MCP `agent_create`/`agent_info`/`agent_list` tools accordingly.

Key changes:
- `checkPair` and `validateQuotas` guard against request > limit at create time using `k8s.io/apimachinery/pkg/api/resource.Quantity.Cmp` — correct tool for the job
- `populateQuota` consolidates values-file read/unmarshal/field-assignment that was previously duplicated in both `List` and `Find`
- All five quota fields (`CPURequest`, `CPULimit`, `MemoryRequest`, `MemoryLimit`, `Pods`) are now first-class on `Info`, `CreateOpts`, `agentValues`, and `agentCreateInput`
- `TestFind_Existing` now asserts all five quota fields; `TestCreate_RequestExceedsLimitReturnsError` covers both CPU and memory cross-validation with correct error message checks

Prior review concerns (missing godoc on exported constants, incomplete `TestFind_Existing` assertions) have been addressed in this revision. I've found nothing worth bothering to flag twice.

<h3>Confidence Score: 5/5</h3>

**[Linus Torvalds Mode]** I've seen worse — this actually does what it claims, the validation logic is correct, the test coverage is real, and nothing obviously blows up. Safe to merge.

Someone actually wrote tests that assert things — shocking. The `checkPair` logic correctly uses `resource.Quantity.Cmp`, default fallbacks in `Create` are applied before validation runs, `populateQuota` handles missing files gracefully with a stderr warning, and all five quota fields flow correctly from CLI/MCP input through to the values YAML. No P1 or P0 issues found; the prior concerns about godoc and test completeness are resolved in this revision. A clean, correct refactor that deserves to ship.

Nothing is on fire. All files look about as good as you could reasonably expect.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/sikifanso/agent_cmd.go | CLI flags cleanly split into --cpu-request/--cpu-limit/--memory-request/--memory-limit using exported defaults; agentListCmd table headers updated to match; no issues |
| internal/agent/agent.go | Exports Default* constants with godoc, adds checkPair/validateQuotas using k8s resource.Quantity, extracts populateQuota helper; all logic correct |
| internal/agent/agent_test.go | TestFind_Existing now asserts all five quota fields; request-exceeds-limit tests cover both CPU and memory; test coverage is complete |
| internal/mcp/agent.go | agentCreateInput updated with all four request/limit fields; agent_list and agent_info output updated to show request/limit pairs clearly |
| docs/superpowers/reports/2026-04-04-argocd-deployment-progress.md | Progress tracker updated marking T17/P23 done (17/17 tasks complete) |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CLI / MCP agent_create] -->|CPURequest, CPULimit\nMemoryRequest, MemoryLimit, Pods| B[agent.Create]
    B --> C{validateName}
    C -->|invalid| Z1[return error]
    C -->|valid| D{agent already exists?}
    D -->|yes| Z2[return error]
    D -->|no| E[Apply defaults if empty]
    E --> F[validateQuotas]
    F -->|checkPair: cpu| G{cpuReq > cpuLim?}
    G -->|yes| Z3[return cpuRequest exceeds cpuLimit error]
    G -->|no| H[checkPair: memory]
    H -->|memReq > memLim?| Z4[return memoryRequest exceeds memoryLimit error]
    H -->|no| I[Write entry YAML\nagents/name.yaml]
    I --> J[Write values YAML\nagents/values/name.yaml]
    J --> K[gitops.Commit]
    K --> L[populateQuota used by List/Find\nto read back quota fields]
```

<sub>Reviews (4): Last reviewed commit: ["fix: address PR review comments — godoc,..."](https://github.com/sikifanso/sikifanso/commit/2c87ee15acd0c1dd36d355eb2dcb47b3bae69ba3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27486465)</sub>

<!-- /greptile_comment -->